### PR TITLE
Enhance chat commands

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,7 @@ website. The server is currently in development and is not yet ready for public 
 - [ ] Server website (located at [Sunset](https://github.com/SunriseCommunity/Sunset))
 - [ ] osu!Direct
 - [ ] Spectating
+- [ ] Stats page (with heart-beat system and operations per minute???)
 
 > [!IMPORTANT]
 > The list of features is in priority order. The higher the feature is, the more important it is.

--- a/Server/Controllers/WebController.cs
+++ b/Server/Controllers/WebController.cs
@@ -18,9 +18,6 @@ public class WebController : ControllerBase
     [HttpPost("osu-submit-modular-selector.php")]
     public async Task<IActionResult> Submit()
     {
-        if (await AuthorizationHelper.IsAuthorized(Request) == false)
-            return BadRequest("Invalid request: Unauthorized");
-
         var result = await ScoreService.SubmitScore(Request);
         return await Task.FromResult<IActionResult>(Ok(result));
     }

--- a/Server/Controllers/WebController.cs
+++ b/Server/Controllers/WebController.cs
@@ -51,7 +51,7 @@ public class WebController : ControllerBase
     [HttpGet("maps/{filename}")]
     public async Task<IActionResult> GetMap(string filename)
     {
-        var file = await BeatmapService.GetBeatmapFileBy(filename);
+        var file = await BeatmapService.GetBeatmapFile(filename);
 
         if (file == null)
             return NotFound("Beatmap not found");

--- a/Server/Data/Database.cs
+++ b/Server/Data/Database.cs
@@ -163,6 +163,15 @@ public sealed class SunriseDb
         return scores.GroupBy(x => x.BeatmapId).Select(x => x.First()).ToList();
     }
 
+    public async Task<Score?> GetUserLastScore(int userId)
+    {
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId);
+
+        var scores = await _orm.SelectManyAsync<Score>(exp);
+
+        return scores.Count == 0 ? null : scores.OrderBy(x => x.WhenPlayed).ToList().Last();
+    }
+
     public async Task<List<Score>> GetBeatmapScores(string beatmapHash, GameMode gameMode, LeaderboardType type = LeaderboardType.Global, Mods mods = Mods.None, User? user = null)
     {
         var exp = new Expr("BeatmapHash", OperatorEnum.Equals, beatmapHash).PrependAnd("GameMode", OperatorEnum.Equals, (int)gameMode);

--- a/Server/Handlers/Chat/ChatMessagePrivateHandler.cs
+++ b/Server/Handlers/Chat/ChatMessagePrivateHandler.cs
@@ -26,7 +26,7 @@ public class ChatMessagePrivateHandler : IHandler
         {
             if (message.Message.StartsWith(Configuration.BotPrefix) || message.Message.StartsWith(Action))
             {
-                return CommandRepository.HandleCommand(message.Message, session);
+                return CommandRepository.HandleCommand(message, session);
             }
         }
 
@@ -45,8 +45,8 @@ public class ChatMessagePrivateHandler : IHandler
                 });
             return Task.CompletedTask;
         }
-        
-        if (receiver is { Attributes.IgnoreNonFriendPm: false } || receiver!.User.FriendsList.Contains(session.User.Id))
+
+        if (receiver is { Attributes.IgnoreNonFriendPm: false } || receiver?.User.FriendsList.Contains(session.User.Id) == true)
         {
             receiver.WritePacket(PacketType.ServerChatMessage, message);
         }

--- a/Server/Handlers/Chat/ChatMessagePrivateHandler.cs
+++ b/Server/Handlers/Chat/ChatMessagePrivateHandler.cs
@@ -14,7 +14,7 @@ public class ChatMessagePrivateHandler : IHandler
 {
     private const string Action = "ACTION";
 
-    public Task Handle(BanchoPacket packet, Session session)
+    public async Task Handle(BanchoPacket packet, Session session)
     {
         var message = new BanchoChatMessage(packet.Data)
         {
@@ -26,7 +26,8 @@ public class ChatMessagePrivateHandler : IHandler
         {
             if (message.Message.StartsWith(Configuration.BotPrefix) || message.Message.StartsWith(Action))
             {
-                return CommandRepository.HandleCommand(message, session);
+                await CommandRepository.HandleCommand(message, session);
+                return;
             }
         }
 
@@ -34,7 +35,12 @@ public class ChatMessagePrivateHandler : IHandler
 
         var receiver = sessions.GetSessionBy(message.Channel);
 
-        if (receiver?.Attributes.AwayMessage is not null)
+        if (receiver is null)
+        {
+            return;
+        }
+
+        if (receiver.Attributes.AwayMessage is not null)
         {
             session.WritePacket(PacketType.ServerChatMessage,
                 new BanchoChatMessage
@@ -43,7 +49,7 @@ public class ChatMessagePrivateHandler : IHandler
                     Channel = Configuration.BotUsername,
                     Message = $"{receiver.User.Username} is away: {receiver.Attributes.AwayMessage}"
                 });
-            return Task.CompletedTask;
+            return;
         }
 
         if (receiver is { Attributes.IgnoreNonFriendPm: false } || receiver?.User.FriendsList.Contains(session.User.Id) == true)
@@ -51,6 +57,15 @@ public class ChatMessagePrivateHandler : IHandler
             receiver.WritePacket(PacketType.ServerChatMessage, message);
         }
 
-        return Task.CompletedTask;
+        await receiver?.FetchUser()!;
+
+        if (receiver.User.SilencedUntil > DateTime.UtcNow)
+        {
+            session.WritePacket(PacketType.ServerChatPmTargetSilenced,
+                new BanchoChatMessage
+                {
+                    Channel = receiver.User.Username
+                });
+        }
     }
 }

--- a/Server/Handlers/Chat/ChatMessagePublicHandler.cs
+++ b/Server/Handlers/Chat/ChatMessagePublicHandler.cs
@@ -3,6 +3,7 @@ using HOPEless.Bancho.Objects;
 using Sunrise.Server.Objects;
 using Sunrise.Server.Objects.CustomAttributes;
 using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Chat;
 using Sunrise.Server.Types.Interfaces;
 using Sunrise.Server.Utils;
 
@@ -18,6 +19,11 @@ public class ChatMessagePublicHandler : IHandler
             Sender = session.User.Username,
             SenderId = session.User.Id
         };
+
+        if (message.Message.StartsWith(Configuration.BotPrefix))
+        {
+            return CommandRepository.HandleCommand(message, session);
+        }
 
         var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
 

--- a/Server/Helpers/AuthorizationHelper.cs
+++ b/Server/Helpers/AuthorizationHelper.cs
@@ -8,8 +8,13 @@ public static class AuthorizationHelper
 {
     public static async Task<bool> IsAuthorized(HttpRequest request)
     {
-        var username = request.Method == "POST" ? request.Form["us"] : request.Query["us"];
-        var passhash = request.Method == "POST" ? request.Form["pass"] : request.Query["ha"];
+        if (request.Method == "POST")
+        {
+            throw new Exception("Invalid request: POST method is not allowed for this endpoint.");
+        }
+
+        var username = request.Query["us"];
+        var passhash = request.Query["ha"];
 
         if (string.IsNullOrEmpty(username) && request.Method == "GET" || string.IsNullOrEmpty(passhash))
         {
@@ -18,14 +23,14 @@ public static class AuthorizationHelper
 
         var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
 
-        var user = await database.GetUser(username: username, token: passhash);
+        var user = await database.GetUser(username: username);
 
         if (user == null)
         {
             return false;
         }
 
-        if (user.Passhash != passhash)
+        if (user.Passhash != passhash || user.IsRestricted)
         {
             return false;
         }

--- a/Server/Objects/ChatCommand.cs
+++ b/Server/Objects/ChatCommand.cs
@@ -1,0 +1,14 @@
+using osu.Shared;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Objects;
+
+public class ChatCommand(IChatCommand handler, PlayerRank requiredPrivileges)
+{
+    public PlayerRank RequiredPrivileges { get; } = requiredPrivileges;
+
+    public Task Handle(Session session, string[]? args)
+    {
+        return handler.Handle(session, args);
+    }
+}

--- a/Server/Objects/ChatCommand.cs
+++ b/Server/Objects/ChatCommand.cs
@@ -3,12 +3,13 @@ using Sunrise.Server.Types.Interfaces;
 
 namespace Sunrise.Server.Objects;
 
-public class ChatCommand(IChatCommand handler, PlayerRank requiredPrivileges)
+public class ChatCommand(IChatCommand handler, PlayerRank requiredPrivileges, bool isGlobal = false)
 {
     public PlayerRank RequiredPrivileges { get; } = requiredPrivileges;
+    public bool IsGlobal { get; set; } = isGlobal;
 
-    public Task Handle(Session session, string[]? args)
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
-        return handler.Handle(session, args);
+        return handler.Handle(session, channel, args);
     }
 }

--- a/Server/Objects/ChatCommands/BeatmapCommand.cs
+++ b/Server/Objects/ChatCommands/BeatmapCommand.cs
@@ -9,7 +9,7 @@ namespace Sunrise.Server.Objects.ChatCommands;
 [ChatCommand("beatmap")]
 public class BeatmapCommand : IChatCommand
 {
-    public async Task Handle(Session session, string[]? args)
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
         if (args == null || args.Length < 1)
         {

--- a/Server/Objects/ChatCommands/BeatmapCommand.cs
+++ b/Server/Objects/ChatCommands/BeatmapCommand.cs
@@ -29,7 +29,7 @@ public class BeatmapCommand : IChatCommand
 
         var beatmap = beatmapSet.Beatmaps.FirstOrDefault(x => x.Id == beatmapId);
 
-        var (pp100, pp99, pp98, pp95) = await Calculators.CalculatePerformancePoints(beatmapId, (int)session.Attributes.Status.PlayMode, precision: false);
+        var (pp100, pp99, pp98, pp95) = await Calculators.CalculatePerformancePoints(beatmapId, beatmap?.ModeInt ?? 0, precision: false);
 
         CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] | 95%: {pp95}pp | 98%: {pp98}pp | 99%: {pp99}pp | 100%: {pp100}pp | {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
     }

--- a/Server/Objects/ChatCommands/HelpCommand.cs
+++ b/Server/Objects/ChatCommands/HelpCommand.cs
@@ -8,9 +8,12 @@ namespace Sunrise.Server.Objects.ChatCommands;
 [ChatCommand("help")]
 public class HelpCommand : IChatCommand
 {
-    public Task Handle(Session session, string[]? args)
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
-        CommandRepository.SendMessage(session, $"Available commands: {Configuration.BotPrefix}" + string.Join($", {Configuration.BotPrefix}", CommandRepository.GetAvailableCommands(session)));
+        var message = $"Available commands: {Configuration.BotPrefix}" + string.Join($", {Configuration.BotPrefix}", CommandRepository.GetAvailableCommands(session));
+
+        CommandRepository.SendMessage(session, message);
+
         return Task.CompletedTask;
     }
 }

--- a/Server/Objects/ChatCommands/HelpCommand.cs
+++ b/Server/Objects/ChatCommands/HelpCommand.cs
@@ -10,7 +10,7 @@ public class HelpCommand : IChatCommand
 {
     public Task Handle(Session session, string[]? args)
     {
-        CommandRepository.SendMessage(session, $"Available commands: {Configuration.BotPrefix}" + string.Join($", {Configuration.BotPrefix}", CommandRepository.GetCurrentCommands()));
+        CommandRepository.SendMessage(session, $"Available commands: {Configuration.BotPrefix}" + string.Join($", {Configuration.BotPrefix}", CommandRepository.GetAvailableCommands(session)));
         return Task.CompletedTask;
     }
 }

--- a/Server/Objects/ChatCommands/MaintenanceCommand.cs
+++ b/Server/Objects/ChatCommands/MaintenanceCommand.cs
@@ -10,7 +10,7 @@ namespace Sunrise.Server.Objects.ChatCommands;
 [ChatCommand("maintenance", PlayerRank.SuperMod)]
 public class MaintenanceCommand : IChatCommand
 {
-    public Task Handle(Session session, string[]? args)
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
         if (args == null || args.Length == 0)
         {

--- a/Server/Objects/ChatCommands/MaintenanceCommand.cs
+++ b/Server/Objects/ChatCommands/MaintenanceCommand.cs
@@ -1,0 +1,62 @@
+using osu.Shared;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands;
+
+[ChatCommand("maintenance", PlayerRank.SuperMod)]
+public class MaintenanceCommand : IChatCommand
+{
+    public Task Handle(Session session, string[]? args)
+    {
+        if (args == null || args.Length == 0)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}maintenance <on/off>");
+            return Task.CompletedTask;
+        }
+
+        switch (args[0])
+        {
+            case "on":
+            {
+                if (Configuration.OnMaintenance)
+                {
+                    CommandRepository.SendMessage(session, "Maintenance mode is already enabled.");
+                    return Task.CompletedTask;
+                }
+
+                Configuration.OnMaintenance = true;
+                CommandRepository.SendMessage(session, "Maintenance mode enabled.");
+
+                var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
+
+                foreach (var userSession in sessions.GetSessions())
+                {
+                    userSession.SendBanchoMaintenance();
+                }
+
+                break;
+            }
+            case "off":
+            {
+                if (!Configuration.OnMaintenance)
+                {
+                    CommandRepository.SendMessage(session, "Maintenance mode is already disabled.");
+                    return Task.CompletedTask;
+                }
+
+                Configuration.OnMaintenance = false;
+                CommandRepository.SendMessage(session, "Maintenance mode disabled.");
+                break;
+            }
+            default:
+                CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}maintenance <on/off>");
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Server/Objects/ChatCommands/MeowCommand.cs
+++ b/Server/Objects/ChatCommands/MeowCommand.cs
@@ -7,7 +7,7 @@ namespace Sunrise.Server.Objects.ChatCommands;
 [ChatCommand("meow")]
 public class MeowCommand : IChatCommand
 {
-    public Task Handle(Session session, string[]? args)
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
         CommandRepository.SendMessage(session, "ヾ(•ω•`)o Meow~");
         return Task.CompletedTask;

--- a/Server/Objects/ChatCommands/Moderation/MaintenanceCommand.cs
+++ b/Server/Objects/ChatCommands/Moderation/MaintenanceCommand.cs
@@ -5,7 +5,7 @@ using Sunrise.Server.Repositories.Chat;
 using Sunrise.Server.Types.Interfaces;
 using Sunrise.Server.Utils;
 
-namespace Sunrise.Server.Objects.ChatCommands;
+namespace Sunrise.Server.Objects.ChatCommands.Moderation;
 
 [ChatCommand("maintenance", PlayerRank.SuperMod)]
 public class MaintenanceCommand : IChatCommand

--- a/Server/Objects/ChatCommands/Moderation/RestrictCommand.cs
+++ b/Server/Objects/ChatCommands/Moderation/RestrictCommand.cs
@@ -1,0 +1,56 @@
+using osu.Shared;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands.Moderation;
+
+[ChatCommand("restrict", PlayerRank.SuperMod)]
+public class RestrictCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length == 0)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}restrict <user id>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var userId))
+        {
+            CommandRepository.SendMessage(session, "Invalid user id.");
+            return;
+        }
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var user = await database.GetUser(userId);
+
+        if (user == null)
+        {
+            CommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        if (user.Privilege >= PlayerRank.SuperMod)
+        {
+            CommandRepository.SendMessage(session, "You cannot restrict this user due to their privilege level.");
+            return;
+        }
+
+        user.IsRestricted = true;
+
+        await database.UpdateUser(user);
+
+        CommandRepository.SendMessage(session, $"User {user.Username} ({user.Id}) has been restricted.");
+
+        var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
+
+        var player = sessions.GetSessionBy(user.Id);
+
+        player?.SendRestriction();
+    }
+}

--- a/Server/Objects/ChatCommands/Moderation/SilenceCommand.cs
+++ b/Server/Objects/ChatCommands/Moderation/SilenceCommand.cs
@@ -1,0 +1,100 @@
+using HOPEless.Bancho;
+using osu.Shared;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands.Moderation;
+
+[ChatCommand("silence", PlayerRank.SuperMod)]
+public class SilenceCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length < 4)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}silence <user id> <amount> <unit (s/m/h/d)> <reason>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var userId))
+        {
+            CommandRepository.SendMessage(session, "Invalid user id.");
+            return;
+        }
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var user = await database.GetUser(userId);
+
+        if (user == null)
+        {
+            CommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        if (user.Privilege >= PlayerRank.SuperMod)
+        {
+            CommandRepository.SendMessage(session, "You cannot silence this user due to their privilege level.");
+            return;
+        }
+
+        if (user.SilencedUntil > DateTime.UtcNow)
+        {
+            CommandRepository.SendMessage(session, $"User is already silenced. He will be unsilenced at {user.SilencedUntil}. UTC+0 ");
+            return;
+        }
+
+        if (!int.TryParse(args[1], out var amount))
+        {
+            CommandRepository.SendMessage(session, "Invalid amount.");
+            return;
+        }
+
+        int time;
+
+        switch (args[2].ToLower())
+        {
+            case "s":
+                time = amount;
+                break;
+            case "m":
+                time = amount * 60;
+                break;
+            case "h":
+                time = amount * 3600;
+                break;
+            case "d":
+                time = amount * 86400;
+                break;
+            default:
+                CommandRepository.SendMessage(session, "Invalid time unit.");
+                return;
+        }
+
+        if (time > 7 * 86400)
+        {
+            CommandRepository.SendMessage(session, "Silence time cannot exceed 7 days.");
+            return;
+        }
+
+        var reason = string.Join(" ", args[3..]);
+
+        user.SilencedUntil = DateTime.UtcNow.AddSeconds(time);
+
+        var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
+
+        var player = sessions.GetSessionBy(user.Id);
+
+        player?.SendSilenceStatus(time, reason);
+
+        sessions.WriteToAllSessions(PacketType.ServerUserSilenced, user.Id);
+
+        await database.UpdateUser(user);
+
+        CommandRepository.SendMessage(session, $"User {user.Username} ({user.Id}) has been silenced until {user.SilencedUntil:yyyy-MM-dd HH:mm:ss}. UTC+0 | Reason: {reason}");
+    }
+}

--- a/Server/Objects/ChatCommands/Moderation/UnrestrictCommand.cs
+++ b/Server/Objects/ChatCommands/Moderation/UnrestrictCommand.cs
@@ -1,0 +1,49 @@
+using osu.Shared;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands.Moderation;
+
+[ChatCommand("unrestrict", PlayerRank.SuperMod)]
+public class UnrestrictCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length == 0)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}unrestrict <user id>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var userId))
+        {
+            CommandRepository.SendMessage(session, "Invalid user id.");
+            return;
+        }
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var user = await database.GetUser(userId);
+
+        if (user == null)
+        {
+            CommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        if (user.IsRestricted == false)
+        {
+            CommandRepository.SendMessage(session, "User is not restricted... yet.");
+            return;
+        }
+
+        user.IsRestricted = false;
+
+        await database.UpdateUser(user);
+
+        CommandRepository.SendMessage(session, $"User {user.Username} ({user.Id}) has been unrestricted.");
+    }
+}

--- a/Server/Objects/ChatCommands/Moderation/UnsilenceCommand.cs
+++ b/Server/Objects/ChatCommands/Moderation/UnsilenceCommand.cs
@@ -1,0 +1,56 @@
+using osu.Shared;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands.Moderation;
+
+[ChatCommand("unsilence", PlayerRank.SuperMod)]
+public class UnsilenceCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length == 0)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}unsilence <user id>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var userId))
+        {
+            CommandRepository.SendMessage(session, "Invalid user id.");
+            return;
+        }
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var user = await database.GetUser(userId);
+
+        if (user == null)
+        {
+            CommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        if (user.SilencedUntil < DateTime.UtcNow)
+        {
+            CommandRepository.SendMessage(session, "User is not silenced.");
+            return;
+        }
+
+        user.SilencedUntil = DateTime.MinValue;
+
+        var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
+
+        var player = sessions.GetSessionBy(user.Id);
+
+        player?.SendSilenceStatus();
+
+        await database.UpdateUser(user);
+
+        CommandRepository.SendMessage(session, $"User {user.Username} ({user.Id}) has been unsilenced.");
+    }
+}

--- a/Server/Objects/ChatCommands/RecentScoreCommand.cs
+++ b/Server/Objects/ChatCommands/RecentScoreCommand.cs
@@ -1,0 +1,38 @@
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Services;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands;
+
+[ChatCommand("rs")]
+public class RecentScoreCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var lastScore = await database.GetUserLastScore(session.User.Id);
+
+        if (lastScore == null)
+        {
+            CommandRepository.SendMessage(session, "No recent score found.");
+            return;
+        }
+
+        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapId: lastScore.BeatmapId);
+
+        if (beatmapSet == null)
+        {
+            CommandRepository.SendMessage(session, "Beatmap not found.");
+            return;
+        }
+
+        var beatmap = beatmapSet.Beatmaps.FirstOrDefault(x => x.Id == lastScore.BeatmapId);
+
+        CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] Mods: {lastScore.Mods} | Acc: {lastScore.Accuracy:0.00}% | {lastScore.PerformancePoints:0.00}pp| {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
+    }
+}

--- a/Server/Objects/ChatCommands/RollCommand.cs
+++ b/Server/Objects/ChatCommands/RollCommand.cs
@@ -1,0 +1,37 @@
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+using static System.Int32;
+
+namespace Sunrise.Server.Objects.ChatCommands;
+
+[ChatCommand("roll", isGlobal: true)]
+public class RollCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        var maxNumber = 100;
+
+        if (args?.Length > 0)
+        {
+            if (TryParse(args[0], out var parsedValue))
+            {
+                maxNumber = parsedValue;
+            }
+        }
+
+        var message = $"[https://osu.{Configuration.Domain}/{session.User.Id} {session.User.Username}] rolls {new Random().Next(0, maxNumber)} point(s)";
+
+        if (channel != null)
+        {
+            channel.SendToChannel(message);
+        }
+        else
+        {
+            CommandRepository.SendMessage(session, message);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Server/Objects/ChatCommands/WhoamiCommand.cs
+++ b/Server/Objects/ChatCommands/WhoamiCommand.cs
@@ -9,14 +9,7 @@ public class WhoamiCommand : IChatCommand
 {
     public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
-        if (channel != null)
-        {
-            channel.SendToChannel($"You are {session.User.Username}. Your ID is {session.User.Id}. Your privileges are {session.User.Privilege}.");
-        }
-        else
-        {
-            CommandRepository.SendMessage(session, $"You are {session.User.Username}. Your ID is {session.User.Id}. Your privileges are {session.User.Privilege}.");
-        }
+        CommandRepository.SendMessage(session, $"You are {session.User.Username}. Your ID is {session.User.Id}. Your privileges are {session.User.Privilege}.");
 
         return Task.CompletedTask;
     }

--- a/Server/Objects/ChatCommands/WhoamiCommand.cs
+++ b/Server/Objects/ChatCommands/WhoamiCommand.cs
@@ -1,0 +1,23 @@
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Objects.ChatCommands;
+
+[ChatCommand("whoami")]
+public class WhoamiCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (channel != null)
+        {
+            channel.SendToChannel($"You are {session.User.Username}. Your ID is {session.User.Id}. Your privileges are {session.User.Privilege}.");
+        }
+        else
+        {
+            CommandRepository.SendMessage(session, $"You are {session.User.Username}. Your ID is {session.User.Id}. Your privileges are {session.User.Privilege}.");
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Server/Objects/ChatCommands/WhoisCommand.cs
+++ b/Server/Objects/ChatCommands/WhoisCommand.cs
@@ -1,0 +1,33 @@
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.CustomAttributes;
+using Sunrise.Server.Repositories.Chat;
+using Sunrise.Server.Types.Interfaces;
+using Sunrise.Server.Utils;
+
+namespace Sunrise.Server.Objects.ChatCommands;
+
+[ChatCommand("whois")]
+public class WhoisCommand : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length == 0)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}whois <username>");
+            return;
+        }
+
+        var username = args[0];
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var user = await database.GetUser(username: username);
+
+        if (user == null)
+        {
+            CommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        CommandRepository.SendMessage(session, $"User {user.Username} ({user.Id}) has {user.Privilege} privileges.");
+    }
+}

--- a/Server/Objects/CustomAttributes/ChatCommandAttribute.cs
+++ b/Server/Objects/CustomAttributes/ChatCommandAttribute.cs
@@ -3,8 +3,9 @@ using osu.Shared;
 namespace Sunrise.Server.Objects.CustomAttributes;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ChatCommandAttribute(string command, PlayerRank requiredRank = PlayerRank.Default) : Attribute
+public class ChatCommandAttribute(string command, PlayerRank requiredRank = PlayerRank.Default, bool isGlobal = false) : Attribute
 {
     public string Command { get; } = command;
     public PlayerRank RequiredRank { get; set; } = requiredRank;
+    public bool IsGlobal { get; set; } = isGlobal;
 }

--- a/Server/Objects/CustomAttributes/ChatCommandAttribute.cs
+++ b/Server/Objects/CustomAttributes/ChatCommandAttribute.cs
@@ -1,7 +1,10 @@
+using osu.Shared;
+
 namespace Sunrise.Server.Objects.CustomAttributes;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class ChatCommandAttribute(string command) : Attribute
+public class ChatCommandAttribute(string command, PlayerRank requiredRank = PlayerRank.Default) : Attribute
 {
     public string Command { get; } = command;
+    public PlayerRank RequiredRank { get; set; } = requiredRank;
 }

--- a/Server/Objects/GetScoresRequest.cs
+++ b/Server/Objects/GetScoresRequest.cs
@@ -27,18 +27,18 @@ public class GetScoresRequest
         Mode = gameMode;
     }
 
-    public string? Hash { get; set; }
+    public string Hash { get; set; }
     public GameMode Mode { get; set; }
     public Mods Mods { get; set; }
     public LeaderboardType LeaderboardType { get; set; }
-    public string? BeatmapSetId { get; set; }
-    public string? BeatmapName { get; set; }
-    public string? Username { get; set; }
+    public string BeatmapSetId { get; set; }
+    public string BeatmapName { get; set; }
+    public string Username { get; set; }
 
     public void ThrowIfHasEmptyFields()
     {
         if (string.IsNullOrEmpty(Hash) || string.IsNullOrEmpty(BeatmapName) ||
-            string.IsNullOrEmpty(Username))
+            string.IsNullOrEmpty(Username) || string.IsNullOrEmpty(BeatmapSetId))
         {
             throw new Exception("Invalid request: Missing parameters");
         }

--- a/Server/Objects/Models/User.cs
+++ b/Server/Objects/Models/User.cs
@@ -30,6 +30,9 @@ public class User
     [Column(DataTypes.Nvarchar, 1024, false)]
     public string Friends { get; set; } = string.Empty;
 
+    [Column(DataTypes.Boolean, false)]
+    public bool IsRestricted { get; set; } = false;
+
     public List<int> FriendsList => Friends.Split(',')
         .Where(x => !string.IsNullOrEmpty(x))
         .Select(int.Parse)

--- a/Server/Objects/Models/User.cs
+++ b/Server/Objects/Models/User.cs
@@ -33,6 +33,9 @@ public class User
     [Column(DataTypes.Boolean, false)]
     public bool IsRestricted { get; set; } = false;
 
+    [Column(DataTypes.DateTime, false)]
+    public DateTime SilencedUntil { get; set; } = DateTime.MinValue;
+
     public List<int> FriendsList => Friends.Split(',')
         .Where(x => !string.IsNullOrEmpty(x))
         .Select(int.Parse)

--- a/Server/Objects/Serializable/Beatmap.cs
+++ b/Server/Objects/Serializable/Beatmap.cs
@@ -99,5 +99,5 @@ public class Beatmap
     public string Checksum { get; set; }
 
     [JsonPropertyName("max_combo")]
-    public int MaxCombo { get; set; }
+    public int? MaxCombo { get; set; }
 }

--- a/Server/Objects/Session.cs
+++ b/Server/Objects/Session.cs
@@ -88,6 +88,12 @@ public class Session
         _helper.WritePacket(PacketType.ServerUserPermissions, User.Privilege);
     }
 
+    public void SendSilenceStatus(int time = 0, string? reason = null)
+    {
+        _helper.WritePacket(PacketType.ServerNotification, $"You have been {(time == 0 ? "un" : "")}silenced. {(reason != null ? $"Reason: {reason}" : "")}");
+        _helper.WritePacket(PacketType.ServerLockClient, time);
+    }
+
     public async Task SendUserPresence()
     {
         var userPresence = await Attributes.GetPlayerPresence();

--- a/Server/Objects/Session.cs
+++ b/Server/Objects/Session.cs
@@ -1,5 +1,6 @@
 using HOPEless.Bancho;
 using HOPEless.Bancho.Objects;
+using osu.Shared;
 using Sunrise.Server.Data;
 using Sunrise.Server.Helpers;
 using Sunrise.Server.Objects.Models;
@@ -39,7 +40,14 @@ public class Session
 
     public void SendBanchoMaintenance()
     {
-        const string message = "Bancho is currently in maintenance mode. Please try again later.";
+        var message = "Server going down for maintenance.";
+
+        if (User.Privilege >= PlayerRank.SuperMod)
+        {
+            return;
+        }
+
+        message += " You will be disconnected shortly.";
 
         _helper.WritePacket(PacketType.ServerLoginReply, (int)LoginResponses.ServerError);
         _helper.WritePacket(PacketType.ServerNotification, message);

--- a/Server/Objects/Session.cs
+++ b/Server/Objects/Session.cs
@@ -53,6 +53,14 @@ public class Session
         _helper.WritePacket(PacketType.ServerNotification, message);
     }
 
+    public void SendRestriction()
+    {
+        const string message = "You have been restricted. Please contact a staff member for more information.";
+
+        _helper.WritePacket(PacketType.ServerLoginReply, (int)LoginResponses.InvalidCredentials);
+        _helper.WritePacket(PacketType.ServerNotification, message);
+    }
+
     public void SendJoinChannel(string channel)
     {
         _helper.WritePacket(PacketType.ServerChatChannelAvailableAutojoin, channel);

--- a/Server/Repositories/Chat/CommandRepository.cs
+++ b/Server/Repositories/Chat/CommandRepository.cs
@@ -93,6 +93,11 @@ public static class CommandRepository
 
         if (action?.StartsWith("is listening to") == true || action?.StartsWith("is watching") == true)
         {
+            if (message.Split('/').Length < 6)
+            {
+                return (null, null);
+            }
+
             var beatmapId = int.TryParse(message.Split('/')[5].Split(' ')[0] ?? string.Empty, out var id) ? id : 0;
             return ("beatmap", [beatmapId.ToString()]);
         }

--- a/Server/Repositories/SessionRepository.cs
+++ b/Server/Repositories/SessionRepository.cs
@@ -104,6 +104,11 @@ public class SessionRepository
         }
     }
 
+    public List<Session> GetSessions()
+    {
+        return _sessions.Values.ToList();
+    }
+
     private void AddBotToSession()
     {
         // TODO: On a side not, it's better to add the bot to the database and then retrieve it from there. Will do that later.
@@ -125,7 +130,7 @@ public class SessionRepository
                 ShowUserLocation = false,
                 Status = new BanchoUserStatus
                 {
-                    Action = BanchoAction.Idle
+                    Action = BanchoAction.Unknown
                 }
             }
         };

--- a/Server/Services/AuthService.cs
+++ b/Server/Services/AuthService.cs
@@ -122,6 +122,11 @@ public static class AuthService
         session.SendFriendsList();
         await sessions.SendCurrentPlayers(session);
 
+        if (session.User.SilencedUntil > DateTime.UtcNow)
+        {
+            session.SendSilenceStatus((int)(session.User.SilencedUntil - DateTime.UtcNow).TotalSeconds);
+        }
+
         sessions.WriteToAllSessions(PacketType.ServerUserPresence, await session.Attributes.GetPlayerPresence());
         sessions.WriteToAllSessions(PacketType.ServerUserData, await session.Attributes.GetPlayerData());
 

--- a/Server/Services/AuthService.cs
+++ b/Server/Services/AuthService.cs
@@ -46,6 +46,16 @@ public static class AuthService
             return RejectLogin(response, "Invalid credentials.");
         }
 
+        if (Configuration.OnMaintenance && user.Privilege < PlayerRank.SuperMod)
+        {
+            return RejectLogin(response, "Server is currently in maintenance mode. Please try again later.", LoginResponses.ServerError);
+        }
+
+        if (user.IsRestricted)
+        {
+            return RejectLogin(response, "Your account is restricted. Please contact support for more information.");
+        }
+
         var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
 
         if (sessions.IsUserOnline(user.Id))
@@ -53,10 +63,6 @@ public static class AuthService
             return RejectLogin(response, "User is already logged in. Try again later.");
         }
 
-        if (Configuration.OnMaintenance && user.Privilege < PlayerRank.SuperMod)
-        {
-            return RejectLogin(response, "Server is currently in maintenance mode. Please try again later.", LoginResponses.ServerError);
-        }
 
         var session = sessions.CreateSession(user, location, loginRequest);
 

--- a/Server/Services/BeatmapService.cs
+++ b/Server/Services/BeatmapService.cs
@@ -11,55 +11,28 @@ public static class BeatmapService
     private const string Api = "https://osu.direct/api/";
     private const string BeatmapMirror = "https://old.ppy.sh/osu/";
 
-    public static async Task<Beatmap?> GetBeatmap(string hash)
+    public static async Task<BeatmapSet?> GetBeatmapSet(int? beatmapId = null, int? beatmapSetId = null, string? beatmapHash = null)
     {
-        var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
-
-        var cachedScores = await redis.Get<Beatmap?>(string.Format(RedisKey.BeatmapHash, hash));
-
-        if (cachedScores != null)
-        {
-            return cachedScores;
-        }
-
-        var beatmap = await RequestsHelper.SendRequest<Beatmap>($"{Api}v2/md5/{hash}");
-
-        if (beatmap == null)
-        {
-            return null;
-        }
-
-        if (Configuration.IgnoreBeatmapRanking)
-        {
-            beatmap.StatusString = "ranked";
-        }
-
-        await redis.Set(string.Format(RedisKey.BeatmapHash, hash), beatmap, TimeSpan.FromMinutes(15));
-
-        return beatmap;
-    }
-
-    public static async Task<BeatmapSet?> GetBeatmapSet(int beatmapId = -1, int beatmapSetId = -1)
-    {
-        if (beatmapId == -1 && beatmapSetId == -1)
+        if (beatmapId == null && beatmapSetId == null && beatmapHash == null)
         {
             return null;
         }
 
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
 
-        var cachedScores = beatmapId != -1
-            ? await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSet, beatmapId))
-            : await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetBySet, beatmapSetId));
+        BeatmapSet? beatmapSet = null;
+        if (beatmapId != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId));
+        if (beatmapSetId != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId));
+        if (beatmapHash != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetByHash, beatmapHash));
 
-        if (cachedScores != null)
+        if (beatmapSet != null)
         {
-            return cachedScores;
+            return beatmapSet;
         }
 
-        var beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(beatmapId != -1
-            ? $"{Api}v2/b/{beatmapId}?full=true"
-            : $"{Api}v2/s/{beatmapSetId}");
+        if (beatmapId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/b/{beatmapId}?full=true");
+        if (beatmapSetId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/s/{beatmapSetId}");
+        if (beatmapHash != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/md5/{beatmapHash}?full=true");
 
         if (beatmapSet == null)
         {
@@ -74,38 +47,41 @@ public static class BeatmapService
             }
         }
 
-        await redis.Set(beatmapId != -1
-                ? string.Format(RedisKey.BeatmapSet, beatmapId)
-                : string.Format(RedisKey.BeatmapSetBySet, beatmapSetId),
-            beatmapSet);
+        // NOTE: Not happy with this robust key system, please refactor if possible.
+
+        if (beatmapId != null) await redis.Set(string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId), beatmapSet);
+        if (beatmapSetId != null) await redis.Set(string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId), beatmapSet);
+        if (beatmapHash != null) await redis.Set(string.Format(RedisKey.BeatmapSetByHash, beatmapHash), beatmapSet);
 
         return beatmapSet;
     }
 
-    public static async Task<byte[]?> GetBeatmapFileBy(int id)
+    public static async Task<byte[]?> GetBeatmapFile(int beatmapId)
     {
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
 
-        var cachedBeatmap = await redis.Get<byte[]>(string.Format(RedisKey.BeatmapFile, id));
+        byte[]? beatmapFile = null;
+        beatmapFile = await redis.Get<byte[]>(string.Format(RedisKey.BeatmapFile, beatmapId));
 
-        if (cachedBeatmap != null)
+        if (beatmapFile != null)
         {
-            return cachedBeatmap;
+            return beatmapFile;
         }
 
-        var beatmap = await RequestsHelper.SendRequest<byte[]>(BeatmapMirror + id);
+        beatmapFile = await RequestsHelper.SendRequest<byte[]>(BeatmapMirror + beatmapId);
 
-        if (beatmap == null)
+        if (beatmapFile == null)
         {
             return null;
         }
 
-        await redis.Set(string.Format(RedisKey.BeatmapFile, id), beatmap, TimeSpan.FromMinutes(60));
+        await redis.Set(string.Format(RedisKey.BeatmapFile, beatmapId), beatmapFile, TimeSpan.FromMinutes(60));
 
-        return beatmap;
+        return beatmapFile;
     }
 
-    public static async Task<byte[]?> GetBeatmapFileBy(string fileName)
+    [Obsolete("Doesn't work?")]
+    public static async Task<byte[]?> GetBeatmapFile(string fileName)
     {
         return await RequestsHelper.SendRequest<byte[]>(BeatmapMirror + fileName);
     }

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -18,9 +18,10 @@ public static class ScoreService
 
         data.ThrowIfHasEmptyFields();
 
-        var beatmap = await BeatmapService.GetBeatmap(data.BeatmapHash!);
+        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapHash: data.BeatmapHash);
+        var beatmap = beatmapSet?.Beatmaps.FirstOrDefault(x => x.Checksum == data.BeatmapHash);
 
-        if (beatmap == null)
+        if (beatmap == null || beatmapSet == null)
         {
             throw new Exception("Invalid request: BeatmapFile not found");
         }
@@ -42,7 +43,7 @@ public static class ScoreService
         var userStats = await database.GetUserStats(score.UserId, score.GameMode);
         var user = await database.GetUser(score.UserId);
 
-        if (userStats == null)
+        if (userStats == null || user == null)
         {
             throw new Exception("Invalid request: UserStats not found");
         }
@@ -71,13 +72,10 @@ public static class ScoreService
         var newPBest = scores.GetNewPersonalScore(score);
         userStats.Rank = await database.GetUserRank(userStats.UserId, userStats.GameMode);
 
-        // Can be simplified to just get beatmapset by hash with full and use it for beatmap too
-        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapSetId: beatmap.BeatmapsetId);
-
-        if (newPBest.LeaderboardRank == 1)
+        if (newPBest.LeaderboardRank == 1 && newPBest.TotalScore > prevPBest?.TotalScore)
         {
             var channels = ServicesProviderHolder.ServiceProvider.GetRequiredService<ChannelRepository>();
-            var message = $"[https://osu.{Configuration.Domain}/{userStats.UserId} {user?.Username}] achieved #1 on [{beatmap.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet?.Artist} - {beatmapSet?.Title} [{beatmap.Version}]] with {score.Accuracy:0.00}% accuracy for {score.PerformancePoints:0.00}pp!";
+            var message = $"[https://osu.{Configuration.Domain}/{userStats.UserId} {user.Username}] achieved #1 on [{beatmap.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap.Version}]] with {score.Accuracy:0.00}% accuracy for {score.PerformancePoints:0.00}pp!";
             channels.GetChannel("#announce")!.SendToChannel(message);
         }
 
@@ -99,22 +97,16 @@ public static class ScoreService
             return $"{(int)BeatmapStatus.NotSubmitted}|false";
         }
 
-        var rawScores = await database.GetBeatmapScores(data.Hash!, data.Mode, data.LeaderboardType, data.Mods, user);
+        var rawScores = await database.GetBeatmapScores(data.Hash, data.Mode, data.LeaderboardType, data.Mods, user);
         var scores = new ScoresHelper(rawScores);
 
-        var beatmap = await BeatmapService.GetBeatmap(data.Hash!);
+        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapSetId: int.Parse(data.BeatmapSetId));
+        var beatmap = beatmapSet?.Beatmaps.FirstOrDefault(x => x.Checksum == data.Hash);
 
-        if (beatmap == null)
+        if (beatmapSet == null || beatmap == null)
         {
-            if (data.BeatmapSetId == null)
-            {
-                return $"{(int)BeatmapStatus.NotSubmitted}|false";
-            }
-
-            // Can be simplified to just get beatmapset by hash with full and use it for beatmap too
-            var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapSetId: int.Parse(data.BeatmapSetId));
-
-            return beatmapSet == null ? $"{(int)BeatmapStatus.NotSubmitted}|false" : $"{(int)BeatmapStatus.NeedsUpdate}|false";
+            // TODO: Check with our db to find out if need's update
+            return $"{(int)BeatmapStatus.NotSubmitted}|false";
         }
 
         if (beatmap.Status < BeatmapStatus.Ranked)
@@ -125,9 +117,8 @@ public static class ScoreService
         var responses = new List<string>
         {
             $"{(int)beatmap.Status}|false|{beatmap.Id}|{beatmap.BeatmapsetId}|{scores.Count}",
-            $"0\n{data.BeatmapName?.Replace(".osu", "")}\n10.0"
+            $"0\n{beatmapSet.Artist} - {beatmapSet.Title}\n10.0"
         };
-
 
         if (scores.Count == 0)
         {
@@ -151,6 +142,7 @@ public static class ScoreService
     {
         var userUrl = $"https://{Configuration.Domain}/user/{user.Id}";
 
+        // TODO: Change playcount and passcount to be from out db
         var beatmapInfo = $"beatmapId:{beatmap.Id}|beatmapSetId:{beatmap.BeatmapsetId}|beatmapPlaycount:{beatmap.Playcount}|beatmapPasscount:{beatmap.Passcount}|approvedDate:{beatmap.LastUpdated:yyyy-MM-dd}";
         var beatmapRanking = $"chartId:beatmap|chartUrl:{beatmap.Url}|chartName:Beatmap Ranking";
         var scoreInfo = string.Join("|", GetChart(prevScore, newScore));

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -72,7 +72,7 @@ public static class ScoreService
         var newPBest = scores.GetNewPersonalScore(score);
         userStats.Rank = await database.GetUserRank(userStats.UserId, userStats.GameMode);
 
-        if (newPBest.LeaderboardRank == 1 && newPBest.TotalScore > prevPBest?.TotalScore)
+        if (newPBest.LeaderboardRank == 1 && prevPBest?.LeaderboardRank != 1)
         {
             var channels = ServicesProviderHolder.ServiceProvider.GetRequiredService<ChannelRepository>();
             var message = $"[https://osu.{Configuration.Domain}/{userStats.UserId} {user.Username}] achieved #1 on [{beatmap.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap.Version}]] with {score.Accuracy:0.00}% accuracy for {score.PerformancePoints:0.00}pp!";

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -48,6 +48,11 @@ public static class ScoreService
             throw new Exception("Invalid request: UserStats not found");
         }
 
+        if (user.Passhash != data.PassHash || user.IsRestricted)
+        {
+            return "error: no";
+        }
+
         var prevUserStats = userStats.Clone();
         var prevPBest = scores.GetPersonalBestOf(score.UserId);
 

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -100,7 +100,8 @@ public static class ScoreService
         var rawScores = await database.GetBeatmapScores(data.Hash, data.Mode, data.LeaderboardType, data.Mods, user);
         var scores = new ScoresHelper(rawScores);
 
-        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapSetId: int.Parse(data.BeatmapSetId));
+        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapSetId: int.Parse(data.BeatmapSetId)) ?? await BeatmapService.GetBeatmapSet(beatmapHash: data.Hash);
+
         var beatmap = beatmapSet?.Beatmaps.FirstOrDefault(x => x.Checksum == data.Hash);
 
         if (beatmapSet == null || beatmap == null)

--- a/Server/Types/Enums/RedisKey.cs
+++ b/Server/Types/Enums/RedisKey.cs
@@ -8,10 +8,9 @@ public static class RedisKey
     public const string UserStats = "user:{0}:stats:{1}";
     public const string Score = "score:{0}";
     public const string Scores = "scores:{0}:leaderboardtype:{1}";
-    public const string BeatmapHash = "beatmap:hash:{0}";
-    public const string Beatmap = "beatmap:{0}";
-    public const string BeatmapSet = "beatmapset:{0}";
-    public const string BeatmapSetBySet = "beatmapset:byset:{0}"; // lol nice naming
+    public const string BeatmapSetByHash = "beatmapset:byhash:{0}";
+    public const string BeatmapSetByBeatmapId = "beatmapset:bybeatmap:{0}";
+    public const string BeatmapSetBySetId = "beatmapset:byset:{0}";
     public const string BeatmapSearch = "beatmapset:serach:{0}";
     public const string BeatmapFile = "beatmap:{0}:file";
 

--- a/Server/Types/Interfaces/IChatCommand.cs
+++ b/Server/Types/Interfaces/IChatCommand.cs
@@ -4,5 +4,5 @@ namespace Sunrise.Server.Types.Interfaces;
 
 public interface IChatCommand
 {
-    Task Handle(Session session, string[]? args);
+    Task Handle(Session session, ChatChannel? channel, string[]? args);
 }

--- a/Server/Utils/Calculators.cs
+++ b/Server/Utils/Calculators.cs
@@ -13,7 +13,7 @@ public static class Calculators
 {
     public static double CalculatePerformancePoints(Score score)
     {
-        var beatmapBytes = BeatmapService.GetBeatmapFileBy(score.BeatmapId).Result;
+        var beatmapBytes = BeatmapService.GetBeatmapFile(score.BeatmapId).Result;
 
         if (beatmapBytes == null)
         {
@@ -39,7 +39,7 @@ public static class Calculators
 
     public static async Task<(double, double, double, double)> CalculatePerformancePoints(int beatmapId, int mode, Mods mods = Mods.None, bool precision = true)
     {
-        var beatmapBytes = await BeatmapService.GetBeatmapFileBy(beatmapId);
+        var beatmapBytes = await BeatmapService.GetBeatmapFile(beatmapId);
 
         if (beatmapBytes == null)
         {

--- a/Server/Utils/Configuration.cs
+++ b/Server/Utils/Configuration.cs
@@ -8,4 +8,5 @@ public static class Configuration
     public static string BotUsername { get; set; } = "Sunshine Bot";
     public static string BotPrefix { get; set; } = "!";
     public static string Domain { get; set; } = "sunrise.local";
+    public static bool OnMaintenance { get; set; } = false;
 }


### PR DESCRIPTION
Changes:
- [x] Add maintenance mode. Blocks everyone except mods from joining the server.
- [x] Add `roll` command, just like in bancho. Works both privately and publicly.
- [x] Add `rs` command which sends your last score. 
- [x] Add `restrict` command to restrict user account. Also adds restriction logic.
- [x] Add `silence` to silence user by ID. 
- [x] Add `whoami` and `whois` command to get user's ID and his privileges. 
And some small fixes/refactors here and there. 