### PR TITLE
Limit usage of external API's

### DIFF
--- a/Server/Controllers/BaseApiController.cs
+++ b/Server/Controllers/BaseApiController.cs
@@ -56,29 +56,6 @@ public class BaseApiController : ControllerBase
     }
 
     [HttpGet]
-    [Route("beatmap/pp/{id:int}")]
-    public async Task<IActionResult> GetPpCalc(int id, [FromQuery(Name = "mode")] int mode)
-    {
-        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
-
-        if (isValidMode != true)
-        {
-            return BadRequest("Invalid mode parameter");
-        }
-
-        var pp = await Calculators.CalculatePerformancePoints(id, mode);
-        var data = JsonSerializer.SerializeToElement(new
-        {
-            acc100 = pp.Item1,
-            acc99 = pp.Item2,
-            acc98 = pp.Item3,
-            acc95 = pp.Item4
-        });
-
-        return Ok(data);
-    }
-
-    [HttpGet]
     [Route("score/{id:int}")]
     public async Task<IActionResult> GetScore(int id)
     {

--- a/Server/Controllers/WebController.cs
+++ b/Server/Controllers/WebController.cs
@@ -45,17 +45,6 @@ public class WebController : ControllerBase
         return Ok(result);
     }
 
-    [HttpGet("maps/{filename}")]
-    public async Task<IActionResult> GetMap(string filename)
-    {
-        var file = await BeatmapService.GetBeatmapFile(filename);
-
-        if (file == null)
-            return NotFound("Beatmap not found");
-
-        return new FileContentResult(file, "application/octet-stream");
-    }
-
     [HttpPost("osu-error.php")]
     public IActionResult OsuError()
     {

--- a/Server/Helpers/RegionHelper.cs
+++ b/Server/Helpers/RegionHelper.cs
@@ -9,11 +9,10 @@ public static class RegionHelper
 
     public static async Task<Location> GetRegion(string ip)
     {
-        var location = await RequestsHelper.SendRequest<Location>($"{Api}{ip}");
-        var region = new Location();
+        var location = await RequestsHelper.SendRequest<Location>($"{Api}{ip}") ?? new Location();
+        location.Ip = ip;
 
-        return location ?? region;
-
+        return location;
     }
 
     public static string GetUserIpAddress(HttpRequest request)

--- a/Server/Helpers/RequestsHelper.cs
+++ b/Server/Helpers/RequestsHelper.cs
@@ -1,5 +1,10 @@
 using System.Net;
 using System.Text.Json;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Utils;
 
 namespace Sunrise.Server.Helpers;
 
@@ -14,6 +19,53 @@ public class RequestsHelper
         Logger = loggerFactory.CreateLogger<RequestsHelper>();
     }
 
+    public static async Task<T?> SendRequest<T>(Session session, ApiType type, object?[] args)
+    {
+        if (await session.IsRateLimited())
+        {
+            Logger.LogWarning($"User {session.User.Id} got rate limited. Ignoring request.");
+            return default;
+        }
+
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+
+        var apis = await database.GetExternalApis(type);
+
+        if (apis is { Count: 0 } or null)
+        {
+            Logger.LogWarning($"No API servers found for {type}.");
+            return default;
+        }
+
+        foreach (var api in apis)
+        {
+            if (args.Length < api.NumberOfRequiredArgs)
+            {
+                Logger.LogWarning($"Not enough arguments for {type} for {api}. Required {api.NumberOfRequiredArgs}, got {args.Length}.");
+                continue;
+            }
+
+            var requestUri = string.Format(api.Url, args);
+
+            var (response, isServerRateLimited) = await SendApiRequest<T>(api.Server, requestUri);
+
+            if (isServerRateLimited)
+            {
+                continue;
+            }
+
+            if (response is not null)
+            {
+                return response;
+            }
+        }
+
+        Logger.LogWarning($"Failed to get response from any API server for {type} with args {string.Join(", ", args)}.");
+
+        return default;
+    }
+
+    [Obsolete("Use only only if we can't get user session.")]
     public static async Task<T?> SendRequest<T>(string requestUri, int requestTry = 0)
     {
         var response = await Client.GetAsync(requestUri);
@@ -22,14 +74,13 @@ public class RequestsHelper
         {
             Logger.LogWarning($"Request to {requestUri} failed with status code {response.StatusCode}");
 
-            if (requestTry < 3)
-            {
-                await Task.Delay(2000);
-                Logger.LogInformation($"Retrying request to {requestUri} (try {requestTry + 1})");
-                return await SendRequest<T>(requestUri, requestTry + 1);
-            }
+            if (requestTry >= 3)
+                return default;
 
-            return default;
+            await Task.Delay(2000);
+            Logger.LogInformation($"Retrying request to {requestUri} (try {requestTry + 1})");
+            return await SendRequest<T>(requestUri, requestTry + 1);
+
         }
 
         if (!response.IsSuccessStatusCode)
@@ -45,5 +96,68 @@ public class RequestsHelper
         var content = await response.Content.ReadAsStringAsync();
 
         return JsonSerializer.Deserialize<T>(content);
+    }
+
+    private static async Task<(T?, bool)> SendApiRequest<T>(ApiServer server, string requestUri)
+    {
+        var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
+        var isServerRateLimited = await redis.Get<bool?>(string.Format(RedisKey.ApiServerRateLimited, server));
+
+        if (isServerRateLimited is true)
+        {
+            Logger.LogWarning($"Server {server} is rate limited. Ignoring request.");
+            return (default, true);
+        }
+
+        var response = await Client.GetAsync(requestUri);
+        var rateLimit = string.Empty;
+
+        switch (server)
+        {
+            case ApiServer.Ppy:
+            case ApiServer.CatboyBest:
+                rateLimit = response.Headers.GetValues("X-RateLimit-Remaining").FirstOrDefault();
+                break;
+            case ApiServer.OsuDirect:
+                rateLimit = response.Headers.GetValues("RateLimit-Remaining").FirstOrDefault();
+                break;
+            case ApiServer.OldPpy:
+                break;
+            case ApiServer.Nerinyan:
+            case ApiServer.OsuOkayu:
+            default:
+                Logger.LogWarning($"Server {server} rate limit headers wasn't set. Ignoring rate limit.");
+                break;
+        }
+
+        if (rateLimit is not null && rateLimit.Equals("1"))
+        {
+            await redis.Set(string.Format(RedisKey.ApiServerRateLimited, server), true, TimeSpan.FromMinutes(1));
+        }
+
+        if (response.StatusCode.Equals(HttpStatusCode.TooManyRequests))
+        {
+            Logger.LogWarning($"Request to {server} failed with status code {response.StatusCode}. Rate limiting server for 10 minutes.");
+
+            await redis.Set(string.Format(RedisKey.ApiServerRateLimited, server), true, TimeSpan.FromMinutes(10));
+
+            return (default, true);
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return (default, false);
+        }
+
+        switch (typeof(T))
+        {
+            case not null when typeof(T) == typeof(byte[]):
+                return ((T)(object)await response.Content.ReadAsByteArrayAsync(), false);
+            case not null when typeof(T) == typeof(string):
+                return ((T)(object)await response.Content.ReadAsStringAsync(), false);
+            default:
+                var content = await response.Content.ReadAsStringAsync();
+                return (JsonSerializer.Deserialize<T>(content), false);
+        }
     }
 }

--- a/Server/Objects/ChatCommands/BeatmapCommand.cs
+++ b/Server/Objects/ChatCommands/BeatmapCommand.cs
@@ -19,7 +19,7 @@ public class BeatmapCommand : IChatCommand
 
         var beatmapId = int.Parse(args[0]);
 
-        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapId);
+        var beatmapSet = await BeatmapService.GetBeatmapSet(session, beatmapId: beatmapId);
 
         if (beatmapSet == null)
         {
@@ -29,8 +29,8 @@ public class BeatmapCommand : IChatCommand
 
         var beatmap = beatmapSet.Beatmaps.FirstOrDefault(x => x.Id == beatmapId);
 
-        var (pp100, pp99, pp98, pp95) = await Calculators.CalculatePerformancePoints(beatmapId, beatmap?.ModeInt ?? 0, precision: false);
+        var (pp100, pp99, pp98, pp95) = await Calculators.CalculatePerformancePoints(session, beatmapId, beatmap?.ModeInt ?? 0);
 
-        CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] | 95%: {pp95}pp | 98%: {pp98}pp | 99%: {pp99}pp | 100%: {pp100}pp | {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
+        CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] | 95%: {pp95:0.00}pp | 98%: {pp98:0.00}pp | 99%: {pp99:0.00}pp | 100%: {pp100:0.00}pp | {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
     }
 }

--- a/Server/Objects/ChatCommands/RecentScoreCommand.cs
+++ b/Server/Objects/ChatCommands/RecentScoreCommand.cs
@@ -23,7 +23,7 @@ public class RecentScoreCommand : IChatCommand
             return;
         }
 
-        var beatmapSet = await BeatmapService.GetBeatmapSet(beatmapId: lastScore.BeatmapId);
+        var beatmapSet = await BeatmapService.GetBeatmapSet(session, beatmapHash: lastScore.BeatmapHash);
 
         if (beatmapSet == null)
         {
@@ -33,6 +33,6 @@ public class RecentScoreCommand : IChatCommand
 
         var beatmap = beatmapSet.Beatmaps.FirstOrDefault(x => x.Id == lastScore.BeatmapId);
 
-        CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] Mods: {lastScore.Mods} | Acc: {lastScore.Accuracy:0.00}% | {lastScore.PerformancePoints:0.00}pp| {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
+        CommandRepository.SendMessage(session, $"[{beatmap!.Url.Replace("ppy.sh", Configuration.Domain)} {beatmapSet.Artist} - {beatmapSet.Title} [{beatmap?.Version}]] Mods: {lastScore.Mods} | Acc: {lastScore.Accuracy:0.00}% | {lastScore.PerformancePoints:0.00}pp | {Parsers.SecondsToString(beatmap?.TotalLength ?? 0)} | {beatmap?.DifficultyRating} ★");
     }
 }

--- a/Server/Objects/Models/BeatmapFile.cs
+++ b/Server/Objects/Models/BeatmapFile.cs
@@ -1,22 +1,21 @@
-﻿using Sunrise.Server.Types.Enums;
-using Watson.ORM.Core;
+﻿using Watson.ORM.Core;
 
 namespace Sunrise.Server.Objects.Models;
 
-[Table("user_file")]
-public class UserFile
+[Table("beatmap_file")]
+public class BeatmapFile
 {
     [Column(true, DataTypes.Int, false)]
     public int Id { get; set; }
 
     [Column(DataTypes.Int, false)]
-    public int OwnerId { get; set; }
+    public int BeatmapId { get; set; }
+
+    [Column(DataTypes.Int, false)]
+    public int BeatmapSetId { get; set; }
 
     [Column(DataTypes.Nvarchar, 64, false)]
     public string Path { get; set; }
-
-    [Column(DataTypes.Int, false)]
-    public FileType Type { get; set; }
 
     [Column(DataTypes.DateTime, false)]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Server/Objects/Models/ExternalApi.cs
+++ b/Server/Objects/Models/ExternalApi.cs
@@ -1,0 +1,26 @@
+﻿using Sunrise.Server.Types.Enums;
+using Watson.ORM.Core;
+
+namespace Sunrise.Server.Objects.Models;
+
+[Table("external_api")]
+public class ExternalApi
+{
+    [Column(true, DataTypes.Int, false)]
+    public int Id { get; set; }
+
+    [Column(DataTypes.Nvarchar, 256, false)]
+    public string Url { get; set; } = string.Empty;
+
+    [Column(DataTypes.Int, false)]
+    public ApiServer Server { get; set; }
+
+    [Column(DataTypes.Int, false)]
+    public ApiType Type { get; set; }
+
+    [Column(DataTypes.Int, false)]
+    public int Priority { get; set; }
+
+    [Column(DataTypes.Int, false)]
+    public int NumberOfRequiredArgs { get; set; }
+}

--- a/Server/Objects/Models/Score.cs
+++ b/Server/Objects/Models/Score.cs
@@ -86,7 +86,7 @@ public class Score
         var sessions = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>();
 
         var split = scoreString.Split(':');
-        var session = sessions.GetSessionBy(split[1]);
+        var session = sessions.GetSessionBy(split[1].Trim());
 
         if (session == null)
             throw new Exception("Session not found for score submission");

--- a/Server/Objects/Serializable/Location.cs
+++ b/Server/Objects/Serializable/Location.cs
@@ -13,5 +13,7 @@ public class Location
     [JsonPropertyName("lon")]
     public float Longitude { get; set; } = 0;
 
+    public string Ip { get; set; } = string.Empty;
+
     public int TimeOffset { get; set; } = 0;
 }

--- a/Server/Objects/Session.cs
+++ b/Server/Objects/Session.cs
@@ -166,6 +166,7 @@ public class Session
                 return true;
             }
 
+            // FIXME: If user spams 1 request each 59 seconds, they will never get back to their limit.
             await redis.Set(key, remaining - 1, TimeSpan.FromMinutes(1));
             return false;
         }

--- a/Server/Objects/SubmitScoreRequest.cs
+++ b/Server/Objects/SubmitScoreRequest.cs
@@ -9,7 +9,13 @@ public class SubmitScoreRequest(HttpRequest request)
     public string? PassHash { get; set; } = request.Form["pass"];
     public string? ScoreTime { get; set; } = request.Form["st"];
     public string? ScoreFailTime { get; set; } = request.Form["ft"];
-    public  string? BeatmapHash { get; set; } = request.Form["bmk"];
+    public string? BeatmapHash { get; set; } = request.Form["bmk"];
+
+    public string? GetUsername()
+    {
+        return ScoreEncoded != null ? ScoreEncoded.Split(':')[1].Trim() : null;
+    }
+
     
     public void ThrowIfHasEmptyFields()
     {

--- a/Server/Objects/SubmitScoreRequest.cs
+++ b/Server/Objects/SubmitScoreRequest.cs
@@ -11,15 +11,9 @@ public class SubmitScoreRequest(HttpRequest request)
     public string? ScoreFailTime { get; set; } = request.Form["ft"];
     public string? BeatmapHash { get; set; } = request.Form["bmk"];
 
-    public string? GetUsername()
-    {
-        return ScoreEncoded != null ? ScoreEncoded.Split(':')[1].Trim() : null;
-    }
-
-    
     public void ThrowIfHasEmptyFields()
     {
-        if (string.IsNullOrEmpty(ScoreEncoded) || string.IsNullOrEmpty(OsuVersion) || string.IsNullOrEmpty(Iv) || string.IsNullOrEmpty(PassHash)  || string.IsNullOrEmpty(BeatmapHash) || Replay == null)
+        if (string.IsNullOrEmpty(ScoreEncoded) || string.IsNullOrEmpty(OsuVersion) || string.IsNullOrEmpty(Iv) || string.IsNullOrEmpty(PassHash) || string.IsNullOrEmpty(BeatmapHash) || Replay == null)
         {
             throw new Exception("Invalid request: Missing parameters");
         }

--- a/Server/Services/BeatmapService.cs
+++ b/Server/Services/BeatmapService.cs
@@ -1,4 +1,6 @@
+using Sunrise.Server.Data;
 using Sunrise.Server.Helpers;
+using Sunrise.Server.Objects;
 using Sunrise.Server.Objects.Serializable;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Types.Enums;
@@ -11,28 +13,27 @@ public static class BeatmapService
     private const string Api = "https://osu.direct/api/";
     private const string BeatmapMirror = "https://old.ppy.sh/osu/";
 
-    public static async Task<BeatmapSet?> GetBeatmapSet(int? beatmapId = null, int? beatmapSetId = null, string? beatmapHash = null)
+    public static async Task<BeatmapSet?> GetBeatmapSet(Session session, int? beatmapSetId = null, string? beatmapHash = null, int? beatmapId = null)
     {
-        if (beatmapId == null && beatmapSetId == null && beatmapHash == null)
+        if (beatmapSetId == null && beatmapHash == null && beatmapId == null)
         {
             return null;
         }
 
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
 
-        BeatmapSet? beatmapSet = null;
-        if (beatmapId != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId));
-        if (beatmapSetId != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId));
-        if (beatmapHash != null) beatmapSet = await redis.Get<BeatmapSet?>(string.Format(RedisKey.BeatmapSetByHash, beatmapHash));
+        var beatmapSet = await redis.Get<BeatmapSet?>([string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId), string.Format(RedisKey.BeatmapSetByHash, beatmapHash), string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId)]);
 
         if (beatmapSet != null)
         {
             return beatmapSet;
         }
 
-        if (beatmapId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/b/{beatmapId}?full=true");
-        if (beatmapSetId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/s/{beatmapSetId}");
-        if (beatmapHash != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>($"{Api}v2/md5/{beatmapHash}?full=true");
+        // TODO: Add beatmapSet in to DB with beatmaps.
+
+        if (beatmapId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByBeatmapId, [beatmapId]);
+        if (beatmapHash != null && beatmapSet == null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByHash, [beatmapHash]);
+        if (beatmapSetId != null && beatmapSet == null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataById, [beatmapSetId]);
 
         if (beatmapSet == null)
         {
@@ -41,48 +42,40 @@ public static class BeatmapService
 
         if (Configuration.IgnoreBeatmapRanking)
         {
-            foreach (var t in beatmapSet.Beatmaps)
+            foreach (var b in beatmapSet.Beatmaps)
             {
-                t.StatusString = "ranked";
+                b.StatusString = "ranked";
             }
         }
 
-        // NOTE: Not happy with this robust key system, please refactor if possible.
+        foreach (var b in beatmapSet.Beatmaps)
+        {
+            await redis.Set([string.Format(RedisKey.BeatmapSetByBeatmapId, b.Id), string.Format(RedisKey.BeatmapSetByHash, b.Checksum)], beatmapSet);
+        }
 
-        if (beatmapId != null) await redis.Set(string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId), beatmapSet);
-        if (beatmapSetId != null) await redis.Set(string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId), beatmapSet);
-        if (beatmapHash != null) await redis.Set(string.Format(RedisKey.BeatmapSetByHash, beatmapHash), beatmapSet);
+        await redis.Set(string.Format(RedisKey.BeatmapSetBySetId, beatmapSet.Id), beatmapSet);
 
         return beatmapSet;
     }
 
-    public static async Task<byte[]?> GetBeatmapFile(int beatmapId)
+    public static async Task<byte[]?> GetBeatmapFile(Session session, int beatmapId)
     {
-        var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
-
-        byte[]? beatmapFile = null;
-        beatmapFile = await redis.Get<byte[]>(string.Format(RedisKey.BeatmapFile, beatmapId));
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+        var beatmapFile = await database.GetBeatmapFile(beatmapId);
 
         if (beatmapFile != null)
         {
             return beatmapFile;
         }
 
-        beatmapFile = await RequestsHelper.SendRequest<byte[]>(BeatmapMirror + beatmapId);
+        beatmapFile = await RequestsHelper.SendRequest<byte[]>(session, ApiType.BeatmapDownload, [beatmapId]);
 
         if (beatmapFile == null)
         {
             return null;
         }
 
-        await redis.Set(string.Format(RedisKey.BeatmapFile, beatmapId), beatmapFile, TimeSpan.FromMinutes(60));
-
+        await database.SetBeatmapFile(beatmapId, beatmapFile);
         return beatmapFile;
-    }
-
-    [Obsolete("Doesn't work?")]
-    public static async Task<byte[]?> GetBeatmapFile(string fileName)
-    {
-        return await RequestsHelper.SendRequest<byte[]>(BeatmapMirror + fileName);
     }
 }

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -19,7 +19,11 @@ public static class ScoreService
 
         data.ThrowIfHasEmptyFields();
 
-        var session = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>().GetSessionBy(username: data.GetUsername() ?? "");
+        var decryptedScore = Parsers.ParseSubmittedScore(data);
+
+        var username = decryptedScore.Split(':')[1].Trim() ?? "";
+
+        var session = ServicesProviderHolder.ServiceProvider.GetRequiredService<SessionRepository>().GetSessionBy(username);
 
         if (session == null)
         {
@@ -33,8 +37,6 @@ public static class ScoreService
         {
             throw new Exception("Invalid request: BeatmapFile not found");
         }
-
-        var decryptedScore = Parsers.ParseSubmittedScore(data);
 
         var score = new Score().SetNewScoreFromString(decryptedScore, beatmap, data.OsuVersion ?? "");
 

--- a/Server/Types/Enums/ApiServer.cs
+++ b/Server/Types/Enums/ApiServer.cs
@@ -1,0 +1,11 @@
+﻿namespace Sunrise.Server.Types.Enums;
+
+public enum ApiServer
+{
+    Ppy = 0,
+    Nerinyan = 1,
+    CatboyBest = 2,
+    OsuDirect = 3,
+    OsuOkayu = 4,
+    OldPpy = 5
+}

--- a/Server/Types/Enums/ApiType.cs
+++ b/Server/Types/Enums/ApiType.cs
@@ -1,0 +1,9 @@
+﻿namespace Sunrise.Server.Types.Enums;
+
+public enum ApiType
+{
+    BeatmapSetDataById = 0,
+    BeatmapSetDataByBeatmapId = 1,
+    BeatmapSetDataByHash = 2,
+    BeatmapDownload = 4
+}

--- a/Server/Types/Enums/RedisKey.cs
+++ b/Server/Types/Enums/RedisKey.cs
@@ -8,15 +8,18 @@ public static class RedisKey
     public const string UserStats = "user:{0}:stats:{1}";
     public const string Score = "score:{0}";
     public const string Scores = "scores:{0}:leaderboardtype:{1}";
-    public const string BeatmapSetByHash = "beatmapset:byhash:{0}";
-    public const string BeatmapSetByBeatmapId = "beatmapset:bybeatmap:{0}";
-    public const string BeatmapSetBySetId = "beatmapset:byset:{0}";
+    public const string BeatmapSetByHash = "beatmapset:hash:{0}";
+    public const string BeatmapSetByBeatmapId = "beatmapset:beatmap:{0}";
+    public const string BeatmapSetBySetId = "beatmapset:set:{0}";
     public const string BeatmapSearch = "beatmapset:serach:{0}";
     public const string BeatmapFile = "beatmap:{0}:file";
 
     public const string Avatar = "avatar:{0}";
     public const string Banner = "banner:{0}";
     public const string Replay = "replay:{0}";
+
+    public const string UserRateLimit = "ratelimit:user:{0}";
+    public const string ApiServerRateLimited = "api:{0}:ratelimited";
 
     public const string LeaderboardGlobal = "leaderboard:global:{0}";
 }

--- a/Server/Utils/Calculators.cs
+++ b/Server/Utils/Calculators.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 using osu.Shared;
 using RosuPP;
 using Sunrise.Server.Data;
+using Sunrise.Server.Objects;
 using Sunrise.Server.Objects.Models;
 using Sunrise.Server.Services;
 using Beatmap = RosuPP.Beatmap;
@@ -11,9 +12,9 @@ namespace Sunrise.Server.Utils;
 
 public static class Calculators
 {
-    public static double CalculatePerformancePoints(Score score)
+    public static double CalculatePerformancePoints(Session session, Score score)
     {
-        var beatmapBytes = BeatmapService.GetBeatmapFile(score.BeatmapId).Result;
+        var beatmapBytes = BeatmapService.GetBeatmapFile(session, score.BeatmapId).Result;
 
         if (beatmapBytes == null)
         {
@@ -37,9 +38,9 @@ public static class Calculators
         };
     }
 
-    public static async Task<(double, double, double, double)> CalculatePerformancePoints(int beatmapId, int mode, Mods mods = Mods.None, bool precision = true)
+    public static async Task<(double, double, double, double)> CalculatePerformancePoints(Session session, int beatmapId, int mode, Mods mods = Mods.None)
     {
-        var beatmapBytes = await BeatmapService.GetBeatmapFile(beatmapId);
+        var beatmapBytes = await BeatmapService.GetBeatmapFile(session, beatmapId);
 
         if (beatmapBytes == null)
         {
@@ -77,7 +78,7 @@ public static class Calculators
             });
         }
 
-        return precision ? (ppList[0], ppList[1], ppList[2], ppList[3]) : (Math.Round(ppList[0]), Math.Round(ppList[1]), Math.Round(ppList[2]), Math.Round(ppList[3]));
+        return (ppList[0], ppList[1], ppList[2], ppList[3]);
 
     }
 

--- a/Server/Utils/Configuration.cs
+++ b/Server/Utils/Configuration.cs
@@ -9,4 +9,5 @@ public static class Configuration
     public static string BotPrefix { get; set; } = "!";
     public static string Domain { get; set; } = "sunrise.local";
     public static bool OnMaintenance { get; set; } = false;
+    public static int UserApiCallsInMinute { get; set; } = 50;
 }


### PR DESCRIPTION
In PR we add each external API we use internal on backend in DB field with endpoint field, server enum and type enum (beatmap data, beatmap file, etc.). It lets us create an easy wrapper for all API calls, where we need to pass only the type of endpoint we want to use and the arguments. 

In the logic of the wrapper, we firstly check if the user is rate limited, by checking his number of API calls left (get set for one minute after each call, so if we have no calls in minute, it will clear, thus returning to default number).

After that we try to get first by priority API with same type and call it, if it being rate limited, we try next one. 

![EuJ1NvEUcAEG3LP_png](https://github.com/user-attachments/assets/950341db-1b82-46f6-a55d-bc5dcc0f052a)

💭 In the future, planning to have same logic on front-end, but swap sessions to "tokens". For beatmap downloading, I think it's better just to forward request to user, so he makes it himself and don't harm our rate limits. 
