### PR TITLE
Cache only light records in Redis. 

### DIFF
--- a/Server/Helpers/PacketHelper.cs
+++ b/Server/Helpers/PacketHelper.cs
@@ -10,7 +10,7 @@ namespace Sunrise.Server.Helpers;
 
 public class PacketHelper
 {
-    private readonly ConcurrentQueue<BanchoPacket> _packets = new ConcurrentQueue<BanchoPacket>();
+    private readonly ConcurrentQueue<BanchoPacket> _packets = new();
 
     [Obsolete("Use WritePacket instead.")]
     public void EnqueuePacket(BanchoPacket packet) => _packets.Enqueue(packet);

--- a/Server/Helpers/RequestsHelper.cs
+++ b/Server/Helpers/RequestsHelper.cs
@@ -70,6 +70,8 @@ public class RequestsHelper
     {
         var response = await Client.GetAsync(requestUri);
 
+        // TODO: Can be refactored to has multiple urls to try and also cache the response.
+
         if (response.StatusCode.Equals(HttpStatusCode.TooManyRequests))
         {
             Logger.LogWarning($"Request to {requestUri} failed with status code {response.StatusCode}");

--- a/Server/Helpers/ScoresHelper.cs
+++ b/Server/Helpers/ScoresHelper.cs
@@ -2,14 +2,9 @@ using Sunrise.Server.Objects.Models;
 
 namespace Sunrise.Server.Helpers;
 
-public class ScoresHelper
+public class ScoresHelper(List<Score> scores)
 {
-    private readonly List<Score> _scores;
-
-    public ScoresHelper(List<Score> scores)
-    {
-        _scores = GetSortedScores(scores);
-    }
+    private readonly List<Score> _scores = GetSortedScores(scores);
 
     public int Count => _scores.Count;
 

--- a/Server/Objects/Models/ExternalApi.cs
+++ b/Server/Objects/Models/ExternalApi.cs
@@ -23,4 +23,14 @@ public class ExternalApi
 
     [Column(DataTypes.Int, false)]
     public int NumberOfRequiredArgs { get; set; }
+    
+    public ExternalApi Fill(ApiType type, ApiServer server, string url, int priority, int numberOfRequiredArgs)
+    {
+        Type = type;
+        Server = server;
+        Url = url;
+        Priority = priority;
+        NumberOfRequiredArgs = numberOfRequiredArgs;
+        return this;
+    }
 }

--- a/Server/Objects/Models/Score.cs
+++ b/Server/Objects/Models/Score.cs
@@ -22,8 +22,8 @@ public class Score
     [Column(DataTypes.Nvarchar, 64, false)]
     public string BeatmapHash { get; set; }
 
-    [Column(DataTypes.Int)]
-    public int? ReplayFileId { get; set; }
+    [Column(DataTypes.Int, false)]
+    public int ReplayFileId { get; set; }
 
     [Column(DataTypes.Int, false)]
     public int TotalScore { get; set; }

--- a/Server/Objects/Session.cs
+++ b/Server/Objects/Session.cs
@@ -155,7 +155,7 @@ public class Session
     public async Task<bool> IsRateLimited()
     {
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
-        var key = string.Format(RedisKey.UserRateLimit, User.Id);
+        var key = RedisKey.UserRateLimit(User.Id);
 
         var remaining = await redis.Get<int?>(key);
 

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -24,9 +24,9 @@ var app = builder.Build();
 CommandRepository.GetHandlers();
 PacketRepository.GetHandlers();
 
-Configuration.InsertApiServersIfNotExists();
-
 ServicesProviderHolder.ServiceProvider = app.Services;
+
+Configuration.InsertApiServersIfNotExists();
 
 app.UseStaticFiles(new StaticFileOptions
 {

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -24,6 +24,8 @@ var app = builder.Build();
 CommandRepository.GetHandlers();
 PacketRepository.GetHandlers();
 
+Configuration.InsertApiServersIfNotExists();
+
 ServicesProviderHolder.ServiceProvider = app.Services;
 
 app.UseStaticFiles(new StaticFileOptions

--- a/Server/Repositories/RedisRepository.cs
+++ b/Server/Repositories/RedisRepository.cs
@@ -8,23 +8,23 @@ public class RedisRepository
 {
 
     private static readonly ConnectionMultiplexer RedisConnection = ConnectionMultiplexer.Connect(Configuration.RedisConnection);
-    public readonly IDatabase Redis = RedisConnection.GetDatabase();
+    private readonly IDatabase _redis = RedisConnection.GetDatabase();
 
     public async Task<T?> Get<T>(string key)
     {
-        var value = await Redis.StringGetAsync(key);
+        var value = await _redis.StringGetAsync(key);
         return value.HasValue ? JsonSerializer.Deserialize<T>(value!) : default;
     }
 
     public async Task<T?> Get<T>(string[] keys)
     {
-        var values = await Redis.StringGetAsync(keys.Select(x => (RedisKey)x).ToArray());
+        var values = await _redis.StringGetAsync(keys.Select(x => (RedisKey)x).ToArray());
 
         foreach (var value in values)
         {
             if (value.HasValue)
             {
-                return JsonSerializer.Deserialize<T>(value);
+                return JsonSerializer.Deserialize<T>(value!);
             }
         }
 
@@ -33,33 +33,33 @@ public class RedisRepository
 
     public async Task Set<T>(string key, T value, TimeSpan? cacheTime = null)
     {
-        await Redis.StringSetAsync(key, JsonSerializer.Serialize(value), cacheTime ?? TimeSpan.FromMinutes(15), flags: CommandFlags.FireAndForget);
+        await _redis.StringSetAsync(key, JsonSerializer.Serialize(value), cacheTime ?? TimeSpan.FromMinutes(15), flags: CommandFlags.FireAndForget);
     }
 
     public async Task Set<T>(string[] keys, T value, TimeSpan? cacheTime = null)
     {
         var values = keys.Select(x => new KeyValuePair<RedisKey, RedisValue>((RedisKey)x, JsonSerializer.Serialize(value))).ToArray();
 
-        await Redis.StringSetAsync(values, flags: CommandFlags.FireAndForget);
+        await _redis.StringSetAsync(values, flags: CommandFlags.FireAndForget);
     }
 
     public async Task Remove(string key)
     {
-        await Redis.KeyDeleteAsync(key);
+        await _redis.KeyDeleteAsync(key);
     }
 
-    public async Task<bool> SortedSetAdd(string key, string value, double score)
+    public async Task<bool> SortedSetAdd(string key, int value, double score)
     {
-        return await Redis.SortedSetAddAsync(key, value, score);
+        return await _redis.SortedSetAddAsync(key, value, score);
     }
 
-    public async Task<double?> SortedSetScore(string key, string value)
+    public async Task<long?> SortedSetRank(string key, int value)
     {
-        return await Redis.SortedSetScoreAsync(key, value);
+        return await _redis.SortedSetRankAsync(key, value, Order.Descending);
     }
 
-    public async Task<bool> SortedSetRemove(string key, string value)
+    public async Task<bool> SortedSetRemove(string key, int value)
     {
-        return await Redis.SortedSetRemoveAsync(key, value);
+        return await _redis.SortedSetRemoveAsync(key, value);
     }
 }

--- a/Server/Services/BeatmapService.cs
+++ b/Server/Services/BeatmapService.cs
@@ -22,14 +22,14 @@ public static class BeatmapService
 
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
 
-        var beatmapSet = await redis.Get<BeatmapSet?>([string.Format(RedisKey.BeatmapSetBySetId, beatmapSetId), string.Format(RedisKey.BeatmapSetByHash, beatmapHash), string.Format(RedisKey.BeatmapSetByBeatmapId, beatmapId)]);
+        var beatmapSet = await redis.Get<BeatmapSet?>([RedisKey.BeatmapSetBySetId(beatmapSetId ?? -1), RedisKey.BeatmapSetByHash(beatmapHash), RedisKey.BeatmapSetByBeatmapId(beatmapId ?? -1)]);
 
         if (beatmapSet != null)
         {
             return beatmapSet;
         }
 
-        // TODO: Add beatmapSet in to DB with beatmaps.
+        // TODO: Add beatmapSet in to DB with beatmaps and move redis logic also to DB.
 
         if (beatmapId != null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByBeatmapId, [beatmapId]);
         if (beatmapHash != null && beatmapSet == null) beatmapSet = await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByHash, [beatmapHash]);
@@ -50,10 +50,10 @@ public static class BeatmapService
 
         foreach (var b in beatmapSet.Beatmaps)
         {
-            await redis.Set([string.Format(RedisKey.BeatmapSetByBeatmapId, b.Id), string.Format(RedisKey.BeatmapSetByHash, b.Checksum)], beatmapSet);
+            await redis.Set([RedisKey.BeatmapSetByHash(b.Checksum), RedisKey.BeatmapSetByBeatmapId(b.Id)], beatmapSet);
         }
 
-        await redis.Set(string.Format(RedisKey.BeatmapSetBySetId, beatmapSet.Id), beatmapSet);
+        await redis.Set(RedisKey.BeatmapSetBySetId(beatmapSet.Id), beatmapSet);
 
         return beatmapSet;
     }

--- a/Server/Services/BeatmapService.cs
+++ b/Server/Services/BeatmapService.cs
@@ -22,7 +22,7 @@ public static class BeatmapService
 
         var redis = ServicesProviderHolder.ServiceProvider.GetRequiredService<RedisRepository>();
 
-        var beatmapSet = await redis.Get<BeatmapSet?>([RedisKey.BeatmapSetBySetId(beatmapSetId ?? -1), RedisKey.BeatmapSetByHash(beatmapHash), RedisKey.BeatmapSetByBeatmapId(beatmapId ?? -1)]);
+        var beatmapSet = await redis.Get<BeatmapSet?>([RedisKey.BeatmapSetBySetId(beatmapSetId ?? -1), RedisKey.BeatmapSetByHash(beatmapHash ?? ""), RedisKey.BeatmapSetByBeatmapId(beatmapId ?? -1)]);
 
         if (beatmapSet != null)
         {
@@ -37,6 +37,7 @@ public static class BeatmapService
 
         if (beatmapSet == null)
         {
+            // TODO: Save null to cache if it requested map not found.
             return null;
         }
 

--- a/Server/Services/FileService.cs
+++ b/Server/Services/FileService.cs
@@ -8,8 +8,15 @@ public static class FileService
     public static async Task<byte[]> GetOsuReplayBytes(int scoreId)
     {
         var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>();
+        
+        var score = await database.GetScore(scoreId);
+        
+        if (score == null)
+        {
+            throw new Exception("Score not found");
+        }
 
-        var replay = await database.GetReplay(scoreId);
+        var replay = await database.GetReplay(score.ReplayFileId);
 
         if (replay == null)
         {

--- a/Server/Types/Enums/RedisKey.cs
+++ b/Server/Types/Enums/RedisKey.cs
@@ -1,25 +1,33 @@
+using osu.Shared;
+
 namespace Sunrise.Server.Types.Enums;
 
 public static class RedisKey
 {
-    public const string OsuVersion = "osu:version:{0}";
+    // Primitives
+    public static string UserRateLimit(int userId) => $"ratelimit:user:{userId}";
+    public static string ApiServerRateLimited(ApiServer server) => $"api:{(int)server}:ratelimited";
+    public static string OsuVersion(string version) => $"osu:version:{version}"; 
 
-    public const string User = "user:{0}";
-    public const string UserStats = "user:{0}:stats:{1}";
-    public const string Score = "score:{0}";
-    public const string Scores = "scores:{0}:leaderboardtype:{1}";
-    public const string BeatmapSetByHash = "beatmapset:hash:{0}";
-    public const string BeatmapSetByBeatmapId = "beatmapset:beatmap:{0}";
-    public const string BeatmapSetBySetId = "beatmapset:set:{0}";
-    public const string BeatmapSearch = "beatmapset:serach:{0}";
-    public const string BeatmapFile = "beatmap:{0}:file";
+    // Objects
+    public static string UserById(int userId) => $"user:id:{userId}";
+    public static string UserByUsername(string username) => $"user:username:{username}";
+    public static string UserByEmail(string email) => $"user:email:{email}";
+    public static string UserStats(int userId, GameMode mode) => $"user:{userId}:stats:{(int)mode}";
+    public static string BeatmapSetByHash(string hash) => $"beatmapset:hash:{hash}";
+    public static string BeatmapSetByBeatmapId(int id) => $"beatmapset:beatmap:{id}";
+    public static string BeatmapSetBySetId(int  id) => $"beatmapset:set:{id}";
+    public static string Score(int scoreId) => $"score:{scoreId}";
+    public static string Scores(string id, string type) => $"scores:{id}:leaderboardtype:{type}";
+    public static string BeatmapSearch(string search) => $"beatmapset:serach:{search}";
 
-    public const string Avatar = "avatar:{0}";
-    public const string Banner = "banner:{0}";
-    public const string Replay = "replay:{0}";
-
-    public const string UserRateLimit = "ratelimit:user:{0}";
-    public const string ApiServerRateLimited = "api:{0}:ratelimited";
-
-    public const string LeaderboardGlobal = "leaderboard:global:{0}";
-}
+    // Records (Includes file paths)
+    public static string BeatmapRecord(int beatmapId) => $"beatmap:{beatmapId}";
+    public static string AvatarRecord(int userId) => $"avatar:{userId}";
+    public static string BannerRecord(int userId) => $"banner:{userId}";
+    public static string ReplayRecord(int replayId) => $"replay:{replayId}";
+    
+    // Sorted Set
+    public static string LeaderboardGlobal(GameMode mode) => $"leaderboard:global:{(int)mode}";
+}    
+    

--- a/Server/Utils/Configuration.cs
+++ b/Server/Utils/Configuration.cs
@@ -1,13 +1,45 @@
+using ExpressionTree;
+using Sunrise.Server.Data;
+using Sunrise.Server.Objects.Models;
+using Sunrise.Server.Types.Enums;
+
 namespace Sunrise.Server.Utils;
 
 public static class Configuration
 {
-    public static bool IgnoreBeatmapRanking { get; set; } = true;
-    public static string RedisConnection { get; set; } = "localhost:6379";
-    public static string WelcomeMessage { get; set; } = "Welcome to Sunrise!";
-    public static string BotUsername { get; set; } = "Sunshine Bot";
-    public static string BotPrefix { get; set; } = "!";
-    public static string Domain { get; set; } = "sunrise.local";
+    public static bool IgnoreBeatmapRanking => true;
+    public static string RedisConnection => "localhost:6379";
+    public static string WelcomeMessage => "Welcome to Sunrise!";
+    public static string BotUsername => "Sunshine Bot";
+    public static string BotPrefix => "!";
+    public static string Domain => "sunrise.local";
     public static bool OnMaintenance { get; set; } = false;
-    public static int UserApiCallsInMinute { get; set; } = 50;
+    public static int UserApiCallsInMinute => 50;
+    
+ public static void InsertApiServersIfNotExists()
+    {
+        var apis = new List<ExternalApi>
+        {
+            new ExternalApi().Fill(ApiType.BeatmapDownload, ApiServer.OldPpy, "https://old.ppy.sh/osu/{0}", 0, 1),
+            new ExternalApi().Fill(ApiType.BeatmapDownload, ApiServer.CatboyBest, "https://catboy.best/osu/{0}n", 1, 1),
+            new ExternalApi().Fill(ApiType.BeatmapDownload, ApiServer.OsuDirect, "https://osu.direct/api/osu/{0}", 2, 1),
+            new ExternalApi().Fill(ApiType.BeatmapSetDataById, ApiServer.OsuDirect, "https://osu.direct/api/v2/s/{0}", 0, 1),
+            new ExternalApi().Fill(ApiType.BeatmapSetDataByBeatmapId, ApiServer.OsuDirect, "https://osu.direct/api/v2/b/{0}?full=true", 0, 1),
+            new ExternalApi().Fill(ApiType.BeatmapSetDataByHash, ApiServer.OsuDirect, "https://osu.direct/api/v2/md5/{0}?full=true", 0, 1)
+        };
+
+        // TODO: Add more mirrors (need also more serializers?)
+        
+        var database = ServicesProviderHolder.ServiceProvider.GetRequiredService<SunriseDb>().GetOrm();
+        
+        if (database == null)
+        {
+            throw new Exception("Don't try to call this method before the database is initialized.");
+        }
+        
+        foreach (var api in from api in apis let existingApi = database.SelectFirst<ExternalApi>(new Expr("Url", OperatorEnum.Equals, api.Url)) where existingApi == null select api)
+        {
+            database.Insert(api);
+        }
+    }
 }


### PR DESCRIPTION
After some reading: ([1](https://stackoverflow.com/questions/34425313/how-to-cache-large-objects-using-redis-cache#41551058),[2](https://stackoverflow.com/questions/55517224/what-is-the-ideal-value-size-range-for-redis-is-100kb-too-large)) I've come to the conclusion that storing beatmaps, images and replays in cache by whole file will cause us big problems in the future, since reading them will lock the single thread Redis has. **Bad.**

So this PR changes logic so we store only a record of the file with path included, so we can get the record from the cache and read the bytes to the client by path. _Good._

+ I've also rewritten Rediskey class, now it has methods instead of blank string constants, much easier to use. 
+ Moved Init ExternalApi logic to Configuration class, also cleaned it a little bit 🌤️ 

Going to test things later and merge if everything works as intended. 