### PR TITLE
Add beatmap(sets) favourites

### DIFF
--- a/Data/Migrations/000008_user_favourites.sql
+++ b/Data/Migrations/000008_user_favourites.sql
@@ -1,0 +1,8 @@
+-- 1. Add new table 
+CREATE TABLE IF NOT EXISTS `user_favourite_beatmap`
+(
+    `Id`           INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `UserId`       INTEGER                           NOT NULL,
+    `BeatmapSetId` INTEGER                           NOT NULL,
+    `DateAdded`    TEXT                              NOT NULL
+)

--- a/Server/API/Serializable/Response/BeatmapSetResponse.cs
+++ b/Server/API/Serializable/Response/BeatmapSetResponse.cs
@@ -5,31 +5,25 @@ namespace Sunrise.Server.API.Serializable.Response;
 
 public class BeatmapSetResponse(BeatmapSet beatmapSet)
 {
-    [JsonPropertyName("id")]
-    public int Id { get; set; } = beatmapSet.Id;
+    [JsonPropertyName("id")] public int Id { get; set; } = beatmapSet.Id;
 
-    [JsonPropertyName("artist")]
-    public string Artist { get; set; } = beatmapSet.Artist;
+    [JsonPropertyName("artist")] public string Artist { get; set; } = beatmapSet.Artist;
 
-    [JsonPropertyName("title")]
-    public string Title { get; set; } = beatmapSet.Title;
+    [JsonPropertyName("title")] public string Title { get; set; } = beatmapSet.Title;
 
-    [JsonPropertyName("creator")]
-    public string Creator { get; set; } = beatmapSet.Creator;
+    [JsonPropertyName("creator")] public string Creator { get; set; } = beatmapSet.Creator;
 
-    [JsonPropertyName("status1")]
-    public string StatusString { get; set; } = beatmapSet.StatusString;
+    [JsonPropertyName("status")] public string StatusString { get; set; } = beatmapSet.StatusString;
 
-    [JsonPropertyName("last_updated")]
-    public DateTime LastUpdated { get; set; } = beatmapSet.LastUpdated;
+    [JsonPropertyName("last_updated")] public DateTime LastUpdated { get; set; } = beatmapSet.LastUpdated;
 
     [JsonPropertyName("ranked_date")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? RankedDate { get; set; } = beatmapSet.RankedDate;
 
-    [JsonPropertyName("video")]
-    public bool HasVideo { get; set; } = beatmapSet.HasVideo;
+    [JsonPropertyName("video")] public bool HasVideo { get; set; } = beatmapSet.HasVideo;
 
     [JsonPropertyName("beatmaps")]
-    public List<BeatmapResponse> Beatmaps { get; set; } = beatmapSet.Beatmaps.Select(beatmap => new BeatmapResponse(beatmap)).ToList();
+    public List<BeatmapResponse> Beatmaps { get; set; } =
+        beatmapSet.Beatmaps.Select(beatmap => new BeatmapResponse(beatmap)).ToList();
 }

--- a/Server/API/Serializable/Response/BeatmapSetsResponse.cs
+++ b/Server/API/Serializable/Response/BeatmapSetsResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.Server.API.Serializable.Response;
+
+public class BeatmapSetsResponse(List<BeatmapSetResponse> sets, int totalCount)
+{
+    [JsonPropertyName("sets")] public List<BeatmapSetResponse> Sets { get; set; } = sets;
+
+    [JsonPropertyName("total_count")] public int TotalCount { get; set; } = totalCount;
+}

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -556,6 +556,27 @@ public sealed class SunriseDb
         await _orm.InsertAsync(favourite);
     }
 
+    public async Task RemoveFavouriteBeatmap(int userId, int beatmapSetId)
+    {
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId).PrependAnd("BeatmapSetId", OperatorEnum.Equals,
+            beatmapSetId);
+        var favourite = await _orm.SelectFirstAsync<UserFavouriteBeatmap?>(exp);
+
+        if (favourite == null)
+            return;
+
+        await _orm.DeleteAsync(favourite);
+    }
+
+    public async Task<bool> IsBeatmapSetFavourited(int userId, int beatmapSetId)
+    {
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId).PrependAnd("BeatmapSetId", OperatorEnum.Equals,
+            beatmapSetId);
+        var favourite = await _orm.SelectFirstAsync<UserFavouriteBeatmap?>(exp);
+
+        return favourite != null;
+    }
+
     public async Task<List<int>> GetUserFavouriteBeatmaps(int userId)
     {
         var exp = new Expr("UserId", OperatorEnum.Equals, userId);

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -36,7 +36,8 @@ public sealed class SunriseDb
 
         _orm.InitializeTables([
             typeof(User), typeof(UserStats), typeof(UserFile), typeof(Restriction), typeof(BeatmapFile), typeof(Score),
-            typeof(Medal), typeof(MedalFile), typeof(UserMedals), typeof(UserStatsSnapshot), typeof(LoginEvent)
+            typeof(Medal), typeof(MedalFile), typeof(UserMedals), typeof(UserStatsSnapshot), typeof(LoginEvent),
+            typeof(UserFavouriteBeatmap)
         ]);
 
         if (appliedMigrations <= 0 && !Configuration.ClearCacheOnStartup) return;
@@ -535,6 +536,32 @@ public sealed class SunriseDb
         var scores = await _orm.SelectManyAsync<Score>(exp);
 
         return scores.GetSortedScoresByScore().FindIndex(x => x.Id == score.Id) + 1;
+    }
+
+    public async Task AddFavouriteBeatmap(int userId, int beatmapSetId)
+    {
+        var favourite = new UserFavouriteBeatmap
+        {
+            UserId = userId,
+            BeatmapSetId = beatmapSetId
+        };
+
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId).PrependAnd("BeatmapSetId", OperatorEnum.Equals,
+            beatmapSetId);
+        var favouriteExists = await _orm.SelectFirstAsync<UserFavouriteBeatmap?>(exp);
+
+        if (favouriteExists != null)
+            return;
+
+        await _orm.InsertAsync(favourite);
+    }
+
+    public async Task<List<int>> GetUserFavouriteBeatmaps(int userId)
+    {
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId);
+        var favourites = await _orm.SelectManyAsync<UserFavouriteBeatmap>(exp);
+
+        return favourites.Select(x => x.BeatmapSetId).ToList();
     }
 
     public async Task<List<int>> GetMostPlayedBeatmapsIds(GameMode? gameMode, int page = 1, int limit = 100)

--- a/Server/Database/Models/UserFavoriteBeatmap.cs
+++ b/Server/Database/Models/UserFavoriteBeatmap.cs
@@ -1,0 +1,15 @@
+using Watson.ORM.Core;
+
+namespace Sunrise.Server.Database.Models;
+
+[Table("user_favourite_beatmap")]
+public class UserFavouriteBeatmap
+{
+    [Column(true, DataTypes.Int, false)] public int Id { get; set; }
+
+    [Column(DataTypes.Int, false)] public int UserId { get; set; }
+
+    [Column(DataTypes.Int, false)] public int BeatmapSetId { get; set; }
+
+    [Column(DataTypes.DateTime, false)] public DateTime DateAdded { get; set; } = DateTime.UtcNow;
+}

--- a/Server/Types/Enums/RequestType.cs
+++ b/Server/Types/Enums/RequestType.cs
@@ -38,6 +38,8 @@ public static class RequestType
     public const string OsuSession = "osu-session.php";
     public const string CheckUpdates = "check-updates.php";
     public const string OsuGetSeasonalBackground = "osu-getseasonal.php";
+    public const string OsuGetFavourites = "osu-getfavourites.php";
+    public const string OsuAddFavourite = "osu-addfavourite.php";
     public const string PostRegister = "/users";
 
     public static bool IsValidRequestType(this string requestType)

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -16,7 +16,7 @@
     "ConnectionString": "localhost:6379",
     "CacheLifeTime": 600,
     "UseCache": true,
-    "ClearCacheOnStartup": true
+    "ClearCacheOnStartup": false
   },
   "Hangfire": {
     "ConnectionString": "Host=localhost;Port=5432;Database=hangfire;Username=postgres;Password=postgres;",


### PR DESCRIPTION
Added favourite beatmapset logic, both for APIs and game client routes.

User can remove, add, check other people's favourites and check personally on some beatmapsets if he has them favourite or not.

LGTM yare yare etc. 🏖