### PR TITLE
Scores changes

### DIFF
--- a/Data/Migrations/000009_save_failed_scores.sql
+++ b/Data/Migrations/000009_save_failed_scores.sql
@@ -1,0 +1,61 @@
+-- 1. Update existing tables
+CREATE TABLE IF NOT EXISTS `score_new`
+(
+    `Id`                INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    `UserId`            INTEGER                           NOT NULL,
+    `BeatmapId`         INTEGER                           NOT NULL,
+    `ScoreHash`         VARCHAR(64) COLLATE NOCASE        NOT NULL,
+    `BeatmapHash`       VARCHAR(64) COLLATE NOCASE        NOT NULL,
+    `ReplayFileId`      INTEGER,
+    `TotalScore`        INTEGER                           NOT NULL,
+    `MaxCombo`          INTEGER                           NOT NULL,
+    `Count300`          INTEGER                           NOT NULL,
+    `Count100`          INTEGER                           NOT NULL,
+    `Count50`           INTEGER                           NOT NULL,
+    `CountMiss`         INTEGER                           NOT NULL,
+    `CountKatu`         INTEGER                           NOT NULL,
+    `CountGeki`         INTEGER                           NOT NULL,
+    `Perfect`           TINYINT                           NOT NULL,
+    `Mods`              INTEGER                           NOT NULL,
+    `Grade`             VARCHAR(64) COLLATE NOCASE        NOT NULL,
+    `IsPassed`          TINYINT                           NOT NULL,
+    `IsRanked`          TINYINT                           NOT NULL,
+    `GameMode`          INTEGER                           NOT NULL,
+    `WhenPlayed`        TEXT                              NOT NULL,
+    `OsuVersion`        VARCHAR(64) COLLATE NOCASE        NOT NULL,
+    `ClientTime`        TEXT                              NOT NULL,
+    `Accuracy`          DECIMAL(100, 2)                   NOT NULL,
+    `PerformancePoints` DECIMAL(100, 2)                   NOT NULL
+);
+
+INSERT INTO score_new
+SELECT Id,
+       UserId,
+       BeatmapId,
+       ScoreHash,
+       BeatmapHash,
+       ReplayFileId,
+       TotalScore,
+       MaxCombo,
+       Count300,
+       Count100,
+       Count50,
+       CountMiss,
+       CountKatu,
+       CountGeki,
+       Perfect,
+       Mods,
+       Grade,
+       IsPassed,
+       IsRanked,
+       GameMode,
+       WhenPlayed,
+       OsuVersion,
+       ClientTime,
+       Accuracy,
+       PerformancePoints
+FROM score;
+DROP TABLE score;
+ALTER TABLE score_new
+    RENAME TO score;
+

--- a/Server/API/Controllers/ScoreController.cs
+++ b/Server/API/Controllers/ScoreController.cs
@@ -35,10 +35,10 @@ public class ScoreController : ControllerBase
         var database = ServicesProviderHolder.GetRequiredService<SunriseDb>();
 
         var score = await database.GetScore(id);
-        if (score == null)
-            return NotFound(new ErrorResponse("Score not found"));
+        if (score?.ReplayFileId == null)
+            return NotFound(new ErrorResponse("Score or replay not found"));
 
-        var replay = await database.GetReplay(score.ReplayFileId);
+        var replay = await database.GetReplay(score.ReplayFileId.Value);
         if (replay == null)
             return NotFound(new ErrorResponse("Replay not found"));
 

--- a/Server/API/Serializable/Response/BeatmapsResponse.cs
+++ b/Server/API/Serializable/Response/BeatmapsResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.Server.API.Serializable.Response;
+
+public class BeatmapsResponse(List<BeatmapResponse> beatmaps, int totalCount)
+{
+    [JsonPropertyName("beatmaps")] public List<BeatmapResponse> Beatmaps { get; set; } = beatmaps;
+
+    [JsonPropertyName("total_count")] public int TotalCount { get; set; } = totalCount;
+}

--- a/Server/API/Serializable/Response/ScoreResponse.cs
+++ b/Server/API/Serializable/Response/ScoreResponse.cs
@@ -7,64 +7,48 @@ namespace Sunrise.Server.API.Serializable.Response;
 
 public class ScoreResponse(Score score)
 {
-    [JsonPropertyName("accuracy")]
-    public double Accuracy { get; set; } = score.Accuracy;
+    [JsonPropertyName("accuracy")] public double Accuracy { get; set; } = score.Accuracy;
 
-    [JsonPropertyName("beatmap_id")]
-    public int BeatmapId { get; set; } = score.BeatmapId;
+    [JsonPropertyName("beatmap_id")] public int BeatmapId { get; set; } = score.BeatmapId;
 
-    [JsonPropertyName("count_100")]
-    public int Count100 { get; set; } = score.Count100;
+    [JsonPropertyName("count_100")] public int Count100 { get; set; } = score.Count100;
 
-    [JsonPropertyName("count_300")]
-    public int Count300 { get; set; } = score.Count300;
+    [JsonPropertyName("count_300")] public int Count300 { get; set; } = score.Count300;
 
-    [JsonPropertyName("count_50")]
-    public int Count50 { get; set; } = score.Count50;
+    [JsonPropertyName("count_50")] public int Count50 { get; set; } = score.Count50;
 
-    [JsonPropertyName("count_geki")]
-    public int CountGeki { get; set; } = score.CountGeki;
+    [JsonPropertyName("count_geki")] public int CountGeki { get; set; } = score.CountGeki;
 
-    [JsonPropertyName("count_katu")]
-    public int CountKatu { get; set; } = score.CountKatu;
+    [JsonPropertyName("count_katu")] public int CountKatu { get; set; } = score.CountKatu;
 
-    [JsonPropertyName("count_miss")]
-    public int CountMiss { get; set; } = score.CountMiss;
+    [JsonPropertyName("count_miss")] public int CountMiss { get; set; } = score.CountMiss;
 
-    [JsonPropertyName("game_mode")]
-    public GameMode GameMode { get; set; } = score.GameMode;
+    [JsonPropertyName("game_mode")] public GameMode GameMode { get; set; } = score.GameMode;
 
-    [JsonPropertyName("grade")]
-    public string Grade { get; set; } = score.Grade;
+    [JsonPropertyName("grade")] public string Grade { get; set; } = score.Grade;
 
-    [JsonPropertyName("id")]
-    public int Id { get; set; } = score.Id;
+    [JsonPropertyName("id")] public int Id { get; set; } = score.Id;
 
-    [JsonPropertyName("is_passed")]
-    public bool IsPassed { get; set; } = score.IsPassed;
+    [JsonPropertyName("is_passed")] public bool IsPassed { get; set; } = score.IsPassed;
 
-    [JsonPropertyName("leaderboard_rank")]
-    public int LeaderboardRank { get; set; } = score.GetLeaderboardRank().Result;
+    [JsonPropertyName("has_replay")] public bool HasReplay { get; set; } = score.ReplayFileId != null;
 
-    [JsonPropertyName("max_combo")]
-    public int MaxCombo { get; set; } = score.MaxCombo;
+    [JsonPropertyName("leaderboard_rank")] public int LeaderboardRank { get; set; } = score.GetLeaderboardRank().Result;
+
+    [JsonPropertyName("max_combo")] public int MaxCombo { get; set; } = score.MaxCombo;
 
     [JsonPropertyName("mods")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Mods { get; set; } = score.Mods.GetModsString();
 
-    [JsonPropertyName("is_perfect")]
-    public bool Perfect { get; set; } = score.Perfect;
+    [JsonPropertyName("is_perfect")] public bool Perfect { get; set; } = score.Perfect;
 
     [JsonPropertyName("performance_points")]
     public double PerformancePoints { get; set; } = score.PerformancePoints;
 
-    [JsonPropertyName("total_score")]
-    public int TotalScore { get; set; } = score.TotalScore;
+    [JsonPropertyName("total_score")] public int TotalScore { get; set; } = score.TotalScore;
 
-    [JsonPropertyName("user_id")]
-    public int UserId { get; set; } = score.UserId;
+    [JsonPropertyName("user_id")] public int UserId { get; set; } = score.UserId;
 
-    [JsonPropertyName("when_played")]
-    public DateTime WhenPlayed { get; set; } = score.WhenPlayed;
+    [JsonPropertyName("when_played")] public DateTime WhenPlayed { get; set; } = score.WhenPlayed;
 }

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -133,6 +133,20 @@ public sealed class SunriseDb
         ], user);
     }
 
+    public async Task<List<Score>> GetTopScores(GameMode mode)
+    {
+        var exp = new Expr("GameMode", OperatorEnum.Equals,
+            (int)mode).PrependAnd("IsRanked", OperatorEnum.Equals, true).PrependAnd("IsPassed", OperatorEnum.Equals,
+            true);
+
+        var scores = await _orm.SelectManyAsync<Score>(exp,
+        [
+            new ResultOrder("PerformancePoints", OrderDirectionEnum.Descending)
+        ]);
+
+        return scores.ToList();
+    }
+
     public async Task<UserStats?> GetUserStats(int userId, GameMode mode, bool useCache = true)
     {
         var cachedStats = await Redis.Get<UserStats?>(RedisKey.UserStats(userId, mode));

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -258,6 +258,20 @@ public sealed class SunriseDb
         return limit == null ? bestScores : bestScores.Take(limit.Value).ToList();
     }
 
+    public async Task<List<int>> GetUserMostPlayedMapsIds(int userId, GameMode mode)
+    {
+        var exp = new Expr("UserId", OperatorEnum.Equals, userId).PrependAnd("GameMode", OperatorEnum.Equals,
+            (int)mode);
+
+        var scores = await _orm.SelectManyAsync<Score>(exp);
+
+        var mostPlayedBeatmap = scores.GroupBy(x => x.BeatmapId).OrderByDescending(x => x.Count()).Select(x => x.Key)
+            .ToList();
+
+        return mostPlayedBeatmap;
+    }
+
+
     public async Task<List<Score>> GetUserScores(int userId, GameMode mode, ScoreTableType type)
     {
         var exp = new Expr("GameMode", OperatorEnum.Equals, (int)mode).PrependAnd("UserId", OperatorEnum.Equals,

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -246,7 +246,7 @@ public sealed class SunriseDb
     {
         var exp = new Expr("UserId", OperatorEnum.Equals, userId).PrependAnd("GameMode", OperatorEnum.Equals, (int)mode)
             .PrependAnd("BeatmapId", OperatorEnum.NotEquals, excludeBeatmapId)
-            .PrependAnd("IsRanked", OperatorEnum.Equals, true);
+            .PrependAnd("IsRanked", OperatorEnum.Equals, true).PrependAnd("IsPassed", OperatorEnum.Equals, true);
 
         var scores = await _orm.SelectManyAsync<Score>(exp,
         [
@@ -266,10 +266,12 @@ public sealed class SunriseDb
         switch (type)
         {
             case ScoreTableType.Best:
-                exp = exp.PrependAnd("IsRanked", OperatorEnum.Equals, true);
+                exp = exp.PrependAnd("IsRanked", OperatorEnum.Equals, true)
+                    .PrependAnd("IsPassed", OperatorEnum.Equals, true);
                 break;
             case ScoreTableType.Top:
-                exp = exp.PrependAnd("IsRanked", OperatorEnum.Equals, true);
+                exp = exp.PrependAnd("IsRanked", OperatorEnum.Equals, true)
+                    .PrependAnd("IsPassed", OperatorEnum.Equals, true);
                 break;
             case ScoreTableType.Recent:
                 break;
@@ -323,7 +325,7 @@ public sealed class SunriseDb
         LeaderboardType type = LeaderboardType.Global, Mods mods = Mods.None, User? user = null)
     {
         var exp = new Expr("BeatmapHash", OperatorEnum.Equals, beatmapHash).PrependAnd("GameMode", OperatorEnum.Equals,
-            (int)gameMode);
+            (int)gameMode).PrependAnd("IsPassed", OperatorEnum.Equals, true);
 
         if (type is LeaderboardType.GlobalWithMods) exp.PrependAnd("Mods", OperatorEnum.Equals, (int)mods);
         if (type is LeaderboardType.Friends) exp.PrependAnd("UserId", OperatorEnum.In, user?.FriendsList);
@@ -532,7 +534,7 @@ public sealed class SunriseDb
     public async Task<int> GetLeaderboardRank(Score score)
     {
         var exp = new Expr("BeatmapHash", OperatorEnum.Equals, score.BeatmapHash).PrependAnd("GameMode",
-            OperatorEnum.Equals, (int)score.GameMode);
+            OperatorEnum.Equals, (int)score.GameMode).PrependAnd("IsPassed", OperatorEnum.Equals, true);
         var scores = await _orm.SelectManyAsync<Score>(exp);
 
         return scores.GetSortedScoresByScore().FindIndex(x => x.Id == score.Id) + 1;

--- a/Server/Database/Models/Score.cs
+++ b/Server/Database/Models/Score.cs
@@ -22,7 +22,7 @@ public class Score
     [Column(DataTypes.Nvarchar, 64, false)]
     public string BeatmapHash { get; set; }
 
-    [Column(DataTypes.Int, false)] public int ReplayFileId { get; set; }
+    [Column(DataTypes.Int)] public int? ReplayFileId { get; set; }
 
     [Column(DataTypes.Int, false)] public int TotalScore { get; set; }
 

--- a/Server/Services/AssetService.cs
+++ b/Server/Services/AssetService.cs
@@ -15,10 +15,10 @@ public static class AssetService
         var database = ServicesProviderHolder.GetRequiredService<SunriseDb>();
 
         var score = await database.GetScore(scoreId);
-        if (score == null)
+        if (score?.ReplayFileId == null)
             return null;
 
-        var replay = await database.GetReplay(score.ReplayFileId);
+        var replay = await database.GetReplay(score.ReplayFileId.Value);
 
         return replay;
     }


### PR DESCRIPTION
Scores focused changes, we now save non-passed scores also in the database to have more accurate most played values. We also add some API routes to expose some specific scores.

Global changes:
- [x] start writing non-passed scores for total played (For better most played values)
- [x] add API for total user score (Add API route `user/{id:int}/mostplayed`)
- [x] add API for top scores on global (Add API route `score/top`)