### PR TITLE
Add Observatory as our beatmap manager

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -43,11 +43,14 @@ website. The server is currently in development and is not yet ready for public 
 1. Clone the repository
 2. Open the project in Visual Studio (or any other IDE)
 3. To set up development environment run:
-    ```bash
-    docker compose -f docker-compose.dev.yml up -d
-    ```
-4. Run the project
-5. (Optional) If you want to connect to the server locally, please refer to
+   ```bash
+   docker compose -f docker-compose.dev.yml up -d
+   ```
+4. Set up the beatmap manager by following the instructions in
+   the [Observatory repository](https://github.com/SunriseCommunity/Observatory). After setting up the beatmap manager,
+   you need to set the `General:ObservatoryUrl` in the `appsettings.{Your Environment}.json` file to the address of the beatmap manager.
+5. Run the project
+6. (Optional) If you want to connect to the server locally, please refer to
    the [Local connection ⚙️](##local-connection)
    section.
 
@@ -59,59 +62,50 @@ website. The server is currently in development and is not yet ready for public 
 2. Open the `hosts` file located in `C:\Windows\System32\drivers\etc\hosts` (C:\ is your system drive) with a text
    editor and add the following line:
 
-    ```hosts
-    ... (rest of the file)
-    
-    # Sunrise Web Section
-    127.0.0.1 sunrise.local
-    127.0.0.1 api.sunrise.local
-    # Sunrise osu! Section
-    127.0.0.1 osu.sunrise.local
-    127.0.0.1 a.sunrise.local
-    127.0.0.1 c.sunrise.local
-    127.0.0.1 assets.sunrise.local
-    127.0.0.1 cho.sunrise.local
-    127.0.0.1 assets.sunrise.local
-    127.0.0.1 c4.sunrise.local
-    127.0.0.1 b.sunrise.local
-    ```
+   ```hosts
+   ... (rest of the file)
+
+   # Sunrise Web Section
+   127.0.0.1 sunrise.local
+   127.0.0.1 api.sunrise.local
+   # Sunrise osu! Section
+   127.0.0.1 osu.sunrise.local
+   127.0.0.1 a.sunrise.local
+   127.0.0.1 c.sunrise.local
+   127.0.0.1 assets.sunrise.local
+   127.0.0.1 cho.sunrise.local
+   127.0.0.1 assets.sunrise.local
+   127.0.0.1 c4.sunrise.local
+   127.0.0.1 b.sunrise.local
+   ```
 
 > [!WARNING]
 > Don't forget to save the file after editing.
 
 3. Generate a self-signed certificate for the domain `sunrise.local` by running the following commands in the terminal:
 
-    ```bash
-    openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout sunrise.local.key -out sunrise.local.crt -subj "/CN=sunrise.local" -addext "subjectAltName=DNS:sunrise.local,DNS:*.sunrise.local,IP:10.0.0.1"
-    ```
+   ```bash
+   openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout sunrise.local.key -out sunrise.local.crt -subj "/CN=sunrise.local" -addext "subjectAltName=DNS:sunrise.local,DNS:*.sunrise.local,IP:10.0.0.1"
+   ```
 
 4. Convert the certificate to the PKCS12 format (for ASP.Net) by running the following command in the terminal:
-    ```bash
-    openssl pkcs12 -export -out sunrise.local.pfx -inkey sunrise.local.key -in sunrise.local.crt -password pass:password
-    ```
+
+   ```bash
+   openssl pkcs12 -export -out sunrise.local.pfx -inkey sunrise.local.key -in sunrise.local.crt -password pass:password
+   ```
 
 5. Import the certificate to the Trusted Root Certification Authorities store by running the following command in the
    terminal:
 
-    ```bash
-    certutil -addstore -f "ROOT" sunrise.local.crt
-    ```
+   ```bash
+   certutil -addstore -f "ROOT" sunrise.local.crt
+   ```
 
 6. Run the server and navigate to `https://sunrise.local/swagger/index.html` to check if the server is running.
 
-## API Endpoints 🛜
-
-### Locally
-
-All endpoints can be checked after running the server locally by navigating
-to `https://{your-domain}/swagger/index.html`.
-
-### Server
-
-In the near future, the server will be hosted on a domain and the API documentation will be available there.
-
 ## Dependencies 📦
 
+- [Observatory (beatmap manager)](https://github.com/SunriseCommunity/Observatory)
 - [rosu-pp-ffi (rosu-pp bindings for C#)](https://github.com/fantasyzhjk/rosu-pp-ffi)
 
 ## Contributing 💖

--- a/Server/Application/Configuration.cs
+++ b/Server/Application/Configuration.cs
@@ -79,14 +79,7 @@ public static class Configuration
     private static string ObservatoryUrl =>
         Config.GetSection("General").GetValue<string?>("ObservatoryUrl") ?? "";
 
-    public static List<ExternalApi> ExternalApis { get; } =
-    [
-        new ExternalApi(ApiType.BeatmapsByBeatmapIds,
-            ApiServer.Nerinyan,
-            "https://proxy.nerinyan.moe/search?option=mapId&s=-2,-1,0,1,2,3,4&q={0}",
-            1,
-            1)
-    ];
+    public static List<ExternalApi> ExternalApis { get; } = [];
 
     public static void Initialize()
     {

--- a/Server/Application/Configuration.cs
+++ b/Server/Application/Configuration.cs
@@ -79,31 +79,8 @@ public static class Configuration
     private static string ObservatoryUrl =>
         Config.GetSection("General").GetValue<string?>("ObservatoryUrl") ?? "";
 
-
-    // TODO: Deprecate after proper (external) beatmap server will be implemented 
-    // For mor information, ask @richardscull
-
     public static List<ExternalApi> ExternalApis { get; } =
     [
-        new ExternalApi(ApiType.BeatmapDownload, ApiServer.OldPpy, "https://old.ppy.sh/osu/{0}", 0, 1),
-
-        new ExternalApi(ApiType.BeatmapSetSearch,
-            ApiServer.CatboyBest,
-            "https://catboy.best/api/v2/search?query={0}&limit={1}&offset={2}&status={3}&mode={4}",
-            1,
-            3),
-        new ExternalApi(ApiType.BeatmapSetDataById, ApiServer.CatboyBest, "https://catboy.best/api/v2/s/{0}", 1, 1),
-
-        new ExternalApi(ApiType.BeatmapDownload, ApiServer.OsuDirect, "https://osu.direct/api/osu/{0}", 2, 1),
-        new ExternalApi(ApiType.BeatmapSetDataById, ApiServer.OsuDirect, "https://osu.direct/api/v2/s/{0}", 1, 1),
-        new ExternalApi(ApiType.BeatmapSetDataByBeatmapId, ApiServer.OsuDirect, "https://osu.direct/api/v2/b/{0}?full=true", 1, 1),
-        new ExternalApi(ApiType.BeatmapSetDataByHash, ApiServer.OsuDirect, "https://osu.direct/api/v2/md5/{0}?full=true", 1, 1),
-        new ExternalApi(ApiType.BeatmapSetSearch,
-            ApiServer.OsuDirect,
-            "https://osu.direct/api/v2/search/?q={0}&amount={1}&offset={2}&status={3}&mode={4}",
-            1,
-            3),
-
         new ExternalApi(ApiType.BeatmapsByBeatmapIds,
             ApiServer.Nerinyan,
             "https://proxy.nerinyan.moe/search?option=mapId&s=-2,-1,0,1,2,3,4&q={0}",
@@ -119,12 +96,18 @@ public static class Configuration
 
     private static void AddObservatoryUrls()
     {
-        if (string.IsNullOrEmpty(ObservatoryUrl)) return;
+        if (string.IsNullOrEmpty(ObservatoryUrl)) throw new Exception("Observatory URL is empty. Please check your configuration. Check README if you have issues with setting up Observatory.");
 
         ExternalApis.AddRange([
+            new ExternalApi(ApiType.BeatmapDownload, ApiServer.Observatory, $"http://{ObservatoryUrl}/osu/{{0}}", 0, 1),
             new ExternalApi(ApiType.BeatmapSetDataById, ApiServer.Observatory, $"http://{ObservatoryUrl}/api/v2/s/{{0}}", 0, 1),
             new ExternalApi(ApiType.BeatmapSetDataByBeatmapId, ApiServer.Observatory, $"http://{ObservatoryUrl}/api/v2/b/{{0}}?full=true", 0, 1),
-            new ExternalApi(ApiType.BeatmapSetDataByHash, ApiServer.Observatory, $"http://{ObservatoryUrl}/api/v2/md5/{{0}}?full=true", 0, 1)
+            new ExternalApi(ApiType.BeatmapSetDataByHash, ApiServer.Observatory, $"http://{ObservatoryUrl}/api/v2/md5/{{0}}?full=true", 0, 1),
+            new ExternalApi(ApiType.BeatmapSetSearch,
+                ApiServer.Observatory,
+                $"http://{ObservatoryUrl}/api/v2/search?query={{0}}&limit={{1}}&offset={{2}}&status={{3}}&mode={{4}}",
+                0,
+                3)
         ]);
     }
 

--- a/Server/Helpers/RequestsHelper.cs
+++ b/Server/Helpers/RequestsHelper.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Text.Json;
+using System.Web;
 using Sunrise.Server.Application;
 using Sunrise.Server.Objects;
 using Sunrise.Server.Repositories;
@@ -48,6 +49,7 @@ public class RequestsHelper
             }
 
             var requestUri = string.Format(api.Url, args);
+            requestUri = SerializeUrlQuery(requestUri);
 
             SunriseMetrics.ExternalApiRequestsCounterInc(type, api.Server, session);
 
@@ -195,5 +197,21 @@ public class RequestsHelper
             Logger.LogError(e, $"Failed to process request to {server} with uri {requestUri}");
             return (default, false);
         }
+    }
+
+    private static string SerializeUrlQuery(string url)
+    {
+        var results = HttpUtility.ParseQueryString(url);
+        var nonEmpty = new Dictionary<string, string>();
+
+        foreach (var k in results.AllKeys)
+        {
+            if (!string.IsNullOrWhiteSpace(results[k]))
+            {
+                nonEmpty.Add(k, results[k]);
+            }
+        }
+
+        return string.Join("&", nonEmpty.Select(kvp => $"{kvp.Key}={kvp.Value}"));
     }
 }

--- a/Server/Helpers/RequestsHelper.cs
+++ b/Server/Helpers/RequestsHelper.cs
@@ -204,6 +204,8 @@ public class RequestsHelper
         var results = HttpUtility.ParseQueryString(url);
         var nonEmpty = new Dictionary<string, string>();
 
+        if (string.IsNullOrWhiteSpace(results.AllKeys[0])) return url;
+
         foreach (var k in results.AllKeys)
         {
             if (!string.IsNullOrWhiteSpace(results[k]))

--- a/Server/Managers/BeatmapManager.cs
+++ b/Server/Managers/BeatmapManager.cs
@@ -61,30 +61,6 @@ public class BeatmapManager
         return beatmapSet;
     }
 
-    public static async Task<List<BeatmapSet>?> SearchBeatmapsByIds(Session session, List<int> ids)
-    {
-        var beatmapSets = await RequestsHelper.SendRequest<List<BeatmapSet>?>(session,
-            ApiType.BeatmapsByBeatmapIds,
-            [string.Join(",", ids.Select(x => x.ToString()))]);
-
-        if (beatmapSets == null) return null;
-
-        // TODO: Save beatmapSets to DB with beatmaps and add redis logic.
-
-        if (Configuration.IgnoreBeatmapRanking)
-            foreach (var b in beatmapSets)
-            {
-                b.StatusString = "ranked";
-
-                foreach (var beatmap in b.Beatmaps)
-                {
-                    beatmap.StatusString = "ranked";
-                }
-            }
-
-        return beatmapSets;
-    }
-
     public static async Task<byte[]?> GetBeatmapFile(BaseSession session, int beatmapId)
     {
         var database = ServicesProviderHolder.GetRequiredService<SunriseDb>();

--- a/Server/Objects/Serializable/Beatmap.cs
+++ b/Server/Objects/Serializable/Beatmap.cs
@@ -50,7 +50,7 @@ public class Beatmap
     public double AR { get; set; }
 
     [JsonPropertyName("bpm")]
-    public double BPM { get; set; }
+    public double BPM { get; set; } = 0;
 
     [JsonPropertyName("convert")]
     public bool Convert { get; set; }
@@ -68,6 +68,7 @@ public class Beatmap
     public double CS { get; set; }
 
     [JsonPropertyName("deleted_at")]
+    // TODO: Is this needed for Observatory?
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime? DeletedAt { get; set; }
 
@@ -81,6 +82,7 @@ public class Beatmap
     public bool IsScoreable { get; set; }
 
     [JsonPropertyName("last_updated")]
+    // TODO: Is this needed for Observatory?
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime LastUpdated { get; set; }
 
@@ -100,7 +102,10 @@ public class Beatmap
     public string Url { get; set; }
 
     [JsonPropertyName("checksum")]
-    public string Checksum { get; set; }
+    public string? Checksum { get; set; }
+
+    [JsonPropertyName("failtimes")]
+    public FailTimes? FailTimes { get; set; }
 
     [JsonPropertyName("max_combo")]
     public int? MaxCombo { get; set; }
@@ -109,4 +114,13 @@ public class Beatmap
     {
         return $"[{DifficultyRating:F2}⭐] {Version.Replace('|', 'I')} {{cs: {CS} / od: {Accuracy} / ar: {AR} / hp: {Drain}}}@{ModeInt},";
     }
+}
+
+public class FailTimes
+{
+    [JsonPropertyName("exit")]
+    public int[]? Exit { get; set; }
+
+    [JsonPropertyName("fail")]
+    public int[]? Fail { get; set; }
 }

--- a/Server/Objects/Serializable/Beatmap.cs
+++ b/Server/Objects/Serializable/Beatmap.cs
@@ -68,7 +68,6 @@ public class Beatmap
     public double CS { get; set; }
 
     [JsonPropertyName("deleted_at")]
-    // TODO: Is this needed for Observatory?
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime? DeletedAt { get; set; }
 
@@ -82,7 +81,6 @@ public class Beatmap
     public bool IsScoreable { get; set; }
 
     [JsonPropertyName("last_updated")]
-    // TODO: Is this needed for Observatory?
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime LastUpdated { get; set; }
 

--- a/Server/Objects/Serializable/BeatmapSet.cs
+++ b/Server/Objects/Serializable/BeatmapSet.cs
@@ -129,7 +129,6 @@ public class BeatmapSet
     [JsonPropertyName("user")]
     public CompactUser? User { get; set; }
 
-    // TODO: Deprecate
     public string ToSearchResult(Session session)
     {
         var beatmaps = Beatmaps.GroupBy(x => x.DifficultyRating).OrderBy(x => x.Key).SelectMany(x => x).Aggregate("",

--- a/Server/Objects/Serializable/BeatmapSet.cs
+++ b/Server/Objects/Serializable/BeatmapSet.cs
@@ -23,38 +23,113 @@ public class BeatmapSet
     [JsonPropertyName("artist")]
     public string Artist { get; set; }
 
-    [JsonPropertyName("title")]
-    public string Title { get; set; }
+    [JsonPropertyName("artist_unicode")]
+    public string ArtistUnicode { get; set; }
 
     [JsonPropertyName("creator")]
     public string Creator { get; set; }
 
-    [JsonPropertyName("user_id")]
-    public int UserId { get; set; }
+    [JsonPropertyName("source")]
+    public string Source { get; set; }
+
+    [JsonPropertyName("tags")]
+    public string Tags { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; }
+
+    [JsonPropertyName("title_unicode")]
+    public string TitleUnicode { get; set; }
+
+    [JsonPropertyName("covers")]
+    public Covers Covers { get; set; }
+
+    [JsonPropertyName("favourite_count")]
+    public int FavouriteCount { get; set; }
+
+    [JsonPropertyName("nsfw")]
+    public bool NSFW { get; set; }
+
+    [JsonPropertyName("offset")]
+    public int Offset { get; set; }
+
+    [JsonPropertyName("play_count")]
+    public int PlayCount { get; set; }
+
+    [JsonPropertyName("preview_url")]
+    public string PreviewUrl { get; set; }
 
     [JsonPropertyName("status")]
     public string StatusString { get; set; }
 
     public BeatmapStatus Status => _statusMap[StatusString ?? "graveyard"];
 
+    [JsonPropertyName("track_id")]
+    public int? TrackId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public int UserId { get; set; }
+
+    [JsonPropertyName("video")]
+    public bool HasVideo { get; set; }
+
+    [JsonPropertyName("bpm")]
+    public double BPM { get; set; }
+
+    [JsonPropertyName("deleted_at")]
+    [JsonConverter(typeof(DateTimeUnixConverter))]
+    public DateTime? DeletedAt { get; set; }
+
+
+    [JsonPropertyName("is_scoreable")]
+    public bool IsScoreable { get; set; }
+
     [JsonPropertyName("last_updated")]
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime LastUpdated { get; set; }
+
+    [JsonPropertyName("legacy_thread_url")]
+    public string? LegacyThreadUrl { get; set; }
+
+    [JsonPropertyName("ranked")]
+    public int Ranked { get; set; }
 
     [JsonPropertyName("ranked_date")]
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime? RankedDate { get; set; }
 
+    [JsonPropertyName("storyboard")]
+    public bool HasStoryboard { get; set; }
+
     [JsonPropertyName("submitted_date")]
     [JsonConverter(typeof(DateTimeUnixConverter))]
     public DateTime SubmittedDate { get; set; }
 
-    [JsonPropertyName("video")]
-    public bool HasVideo { get; set; }
+    [JsonPropertyName("availability")]
+    public BeatmapAvailability Availability { get; set; }
 
     [JsonPropertyName("beatmaps")]
     public Beatmap[] Beatmaps { get; set; }
 
+    [JsonPropertyName("converts")]
+    public Beatmap[] ConvertedBeatmaps { get; set; }
+
+    [JsonPropertyName("description")]
+    public BeatmapSetDescription Description { get; set; }
+
+    [JsonPropertyName("genre")]
+    public BeatmapSetGenre Genre { get; set; }
+
+    [JsonPropertyName("language")]
+    public BeatmapSetLanguage Language { get; set; }
+
+    [JsonPropertyName("related_users")]
+    public CompactUser[]? RelatedUsers { get; set; }
+
+    [JsonPropertyName("user")]
+    public CompactUser? User { get; set; }
+
+    // TODO: Deprecate
     public string ToSearchResult(Session session)
     {
         var beatmaps = Beatmaps.GroupBy(x => x.DifficultyRating).OrderBy(x => x.Key).SelectMany(x => x).Aggregate("",
@@ -67,4 +142,76 @@ public class BeatmapSet
 
         return $"{Id}.osz|{Artist.Replace('|', 'I')}|{Title.Replace('|', 'I')}|{Creator.Replace('|', 'I')}|{(int)beatmapStatus}|10.0|{lastUpdatedTime}|{Id}|0|{hasVideo}|0|0|0|{beatmaps}";
     }
+}
+
+public class Covers
+{
+    [JsonPropertyName("card")]
+    public string Card { get; set; }
+
+    [JsonPropertyName("card@2x")]
+    public string Card2x { get; set; }
+
+    [JsonPropertyName("cover")]
+    public string Cover { get; set; }
+
+    [JsonPropertyName("cover@2x")]
+    public string Cover2x { get; set; }
+
+    [JsonPropertyName("list")]
+    public string List { get; set; }
+
+    [JsonPropertyName("list@2x")]
+    public string List2x { get; set; }
+
+    [JsonPropertyName("slimcover")]
+    public string SlimCover { get; set; }
+
+    [JsonPropertyName("slimcover@2x")]
+    public string SlimCover2x { get; set; }
+}
+
+public class BeatmapAvailability
+{
+    [JsonPropertyName("download_disabled")]
+    public bool DownloadDisabled { get; set; }
+
+    [JsonPropertyName("more_information")]
+    public string? MoreInformation { get; set; }
+}
+
+public class BeatmapSetGenre
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+}
+
+public class BeatmapSetLanguage
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+}
+
+public class BeatmapSetDescription
+{
+    [JsonPropertyName("description")]
+    public string description { get; set; }
+}
+
+public class CompactUser
+{
+    [JsonPropertyName("avatar_url")]
+    public string AvatarUrl { get; set; }
+
+    [JsonPropertyName("country_code")]
+    public string CountryCode { get; set; }
+
+    [JsonPropertyName("username")]
+    public string Username { get; set; }
 }

--- a/Server/Services/BeatmapService.cs
+++ b/Server/Services/BeatmapService.cs
@@ -1,6 +1,4 @@
-using osu.Shared;
 using Sunrise.Server.Application;
-using Sunrise.Server.Database;
 using Sunrise.Server.Helpers;
 using Sunrise.Server.Managers;
 using Sunrise.Server.Objects;
@@ -27,34 +25,10 @@ public static class BeatmapService
         string mode,
         int ranked)
     {
-        var searchMostPlayed = query.Length >= 11 && query[..11] == "Most Played";
-        query = query.Length switch
-        {
-            >= 6 when query[..6] == "Newest" => query[6..],
-            >= 9 when query[..9] == "Top Rated" => query[9..],
-            >= 11 when query[..11] == "Most Played" => query[11..],
-            _ => query
-        };
-
         var parsedStatus = Parsers.WebStatusToSearchStatus(ranked);
         var beatmapStatus = parsedStatus == BeatmapStatusSearch.Any ? "" : parsedStatus.ToString("D");
-
-        List<BeatmapSet>? beatmapSets;
-
-        if (searchMostPlayed)
-        {
-            var database = ServicesProviderHolder.GetRequiredService<SunriseDb>();
-            var ids = await database.GetMostPlayedBeatmapsIds(
-                Enum.TryParse<GameMode>(mode, out var modeEnum) ? modeEnum : null, page);
-
-            beatmapSets = await BeatmapManager.SearchBeatmapsByIds(session, ids.Take(50).ToList());
-            beatmapSets?.AddRange(await BeatmapManager.SearchBeatmapsByIds(session, ids.Skip(50).Take(50).ToList()) ??
-                                  []); // Not the best, but API ignores my page size parameter.
-        }
-        else
-        {
-            beatmapSets = await SearchBeatmapSet(session, beatmapStatus, mode, page, query);
-        }
+        
+        var beatmapSets = await SearchBeatmapSet(session, beatmapStatus, mode, page, query);
 
         if (beatmapSets == null)
             return "0";
@@ -70,7 +44,8 @@ public static class BeatmapService
     private static async Task<List<BeatmapSet>?> SearchBeatmapSet(Session session, string? rankedStatus, string mode,
         int page, string query)
     {
-        var beatmapSets = await RequestsHelper.SendRequest<List<BeatmapSet>?>(session, ApiType.BeatmapSetSearch,
+        var beatmapSets = await RequestsHelper.SendRequest<List<BeatmapSet>?>(session,
+            ApiType.BeatmapSetSearch,
             [query, 100, page, rankedStatus, mode]);
 
         if (beatmapSets == null) return null;
@@ -82,7 +57,10 @@ public static class BeatmapService
             {
                 b.StatusString = "ranked";
 
-                foreach (var beatmap in b.Beatmaps) beatmap.StatusString = "ranked";
+                foreach (var beatmap in b.Beatmaps)
+                {
+                    beatmap.StatusString = "ranked";
+                }
             }
 
         return beatmapSets;


### PR DESCRIPTION
So, for the past few days I worked on ["Observatory"](https://github.com/SunriseCommunity/Observatory), which is "plug and use" beatmap manager, more specifically developed for this server.

It works as manager for osu! API and any popular existing beatmap mirror. It has internal database and cache for beatmaps and other data. 

I just thought that it would be easier to maintain and scale a big network of beatmap mirrors (well, until we get our personal mirror wink wink) as a different application. 

**AS NOTE: YOU WILL NEED TO SET UP AN OBSERVATORY INSTANCE IN DOCKER OR LOCALLY TO HOST SUNRISE FROM THIS POINT FORWARD**

![7zuf1g-2253127466](https://github.com/user-attachments/assets/76a0960a-7b7b-483d-bba2-d04675917a94)

P.S: This PR it also simplifies osu direct search, removing "Most played" logic from our side, to bancho's one. Even if I would resurrect the idea of fetching our most played beatmaps, it would be easier to be done in Sunset repo. 
