### PR TITLE
Feat: Add "web/osu-getbeatmapinfo.php" endpoint.

### DIFF
--- a/Server/Controllers/WebController.cs
+++ b/Server/Controllers/WebController.cs
@@ -88,6 +88,22 @@ public class WebController : ControllerBase
         return Ok();
     }
 
+
+
+    [HttpPost(RequestType.OsuGetBeatmapInfo)]
+    public IActionResult GetBeatmapInfo()
+    {
+        // This is a dummy response for a multiplayer matches.
+        // By my understanding, client sends us list of Filenames and/or Ids to be parsed into a list of beatmaps.
+        // This is probably done to ensure that downloaded beatmaps are the same for all players.
+        // BUT - we can't really find beatmaps by their filenames (check PS to find out why), so we just return a dummy response.
+        // With that we both satisfy the client and don't break anything. Even if map is not ranked, we will handle it properly on submission.
+        // P.S: Due to sanitization of filename, artist/title/creator not always match their actual values.
+        // If you found any problem with this solution, please create an issue for it. -richardscull
+
+        return Ok(string.Join("\n", Enumerable.Range(0, 100).Select(i => $"{i}||||1|N|N|N|N")));
+    }
+
     [HttpGet(RequestType.OsuMarkAsRead)]
     public IActionResult OsuMarkAsRead()
     {

--- a/Server/Types/Enums/RequestType.cs
+++ b/Server/Types/Enums/RequestType.cs
@@ -34,6 +34,7 @@ public static class RequestType
     public const string OsuError = "osu-error.php";
     public const string LastFm = "lastfm.php";
     public const string OsuMarkAsRead = "osu-markasread.php";
+    public const string OsuGetBeatmapInfo = "osu-getbeatmapinfo.php";
     public const string BanchoConnect = "bancho_connect.php";
     public const string OsuSession = "osu-session.php";
     public const string CheckUpdates = "check-updates.php";


### PR DESCRIPTION
This PR should resolve issues then after downloading beatmap in multiplayer, playing it not submits score to global leaderboard.

At first, I wanted to search by artist/title/ via osu search to find beatmap, but this idea failed due to osu serializing filename for windows, which can be crucial for naming. 
For example: 
- Minor change: `Colors*Slash - Colors Power ni Omakasero!` -> `ColorsSlash - Colors Power ni Omakasero!` (removes * in artist name)
- Massive change: `x0o0x_ - / / // / /` -> `x0o0x_ - _ _ __ _ _` (completely changes title)

The only way to get conversion from filename to beatmap, is:
A. Use `osu.ppy.sh` endpoint with someone's credentials
B. Have beatmap mirror with support for searching by filename (I don't think any with this feature exists right now)

------

TLDR: We can't really decode filenames, so we will just spoon-feed with dummy responses of ranked maps without user's personal best. It **will** submit scores, even with right data. So I think this will settle. 
