### PR TITLE
fix: Database update fix in user_file table

### DIFF
--- a/Data/Migrations/000014_user_file_improvement.sql
+++ b/Data/Migrations/000014_user_file_improvement.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS `user_file_new`
+(
+    `Id`        INTEGER PRIMARY KEY AUTOINCREMENT  NOT NULL,
+    `OwnerId`   INTEGER                            NOT NULL,
+    `Path`      VARCHAR(2147483647) COLLATE NOCASE NOT NULL,
+    `Type`      INTEGER                            NOT NULL,
+    `CreatedAt` TEXT                               NOT NULL,
+    `UpdatedAt` TEXT                               NOT NULL
+);
+
+INSERT INTO user_file_new
+SELECT Id,
+       OwnerId,
+       Path,
+       Type,
+       CreatedAt,
+       CreatedAt
+FROM user_file;
+
+DROP TABLE user_file;
+ALTER TABLE user_file_new
+    RENAME TO user_file;
+
+DELETE FROM user_file
+WHERE Id IN (
+    SELECT Id
+    FROM (
+        SELECT Id, 
+               ROW_NUMBER() OVER (PARTITION BY OwnerId, Type ORDER BY CreatedAt ASC) AS rn
+
+        FROM user_file
+    )
+    WHERE rn > 1
+);

--- a/Data/Migrations/000014_user_file_improvement.sql
+++ b/Data/Migrations/000014_user_file_improvement.sql
@@ -29,6 +29,7 @@ WHERE Id IN (
                ROW_NUMBER() OVER (PARTITION BY OwnerId, Type ORDER BY CreatedAt ASC) AS rn
 
         FROM user_file
+        WHERE Type IN (1, 2) -- Avatar and Banner
     )
     WHERE rn > 1
 );

--- a/Server/Database/Models/UserFile.cs
+++ b/Server/Database/Models/UserFile.cs
@@ -16,4 +16,6 @@ public class UserFile
     [Column(DataTypes.Int, false)] public FileType Type { get; set; }
 
     [Column(DataTypes.DateTime, false)] public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Column(DataTypes.DateTime, false)] public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Server/Database/Services/User/Services/UserFileService.cs
+++ b/Server/Database/Services/User/Services/UserFileService.cs
@@ -42,13 +42,15 @@ public class UserFileService
             Type = FileType.Avatar
         };
         
-        var exp = new Expr("OwnerId", OperatorEnum.Equals, userId).PrependAnd("Type", OperatorEnum.Equals, (int)FileType.Banner);
+        var exp = new Expr("OwnerId", OperatorEnum.Equals, userId).PrependAnd("Type", OperatorEnum.Equals, (int)FileType.Avatar);
         var prevRecord =  await _database.SelectFirstAsync<UserFile?>(exp);
 
         if (prevRecord != null)
         {
             record.Id = prevRecord.Id;
+            record.CreatedAt = prevRecord.CreatedAt;
             record = await _database.UpdateAsync(record);
+
         }
         else
         {
@@ -155,6 +157,7 @@ public class UserFileService
         if (prevRecord != null)
         {
             record.Id = prevRecord.Id;
+            record.CreatedAt = prevRecord.CreatedAt;
             record = await _database.UpdateAsync(record);
         }
         else


### PR DESCRIPTION
Corrected information about avatar update in database, fixed issue when avatar update replaced row about banner update.
Added migration for database with new column in user_file: UpdatedAt, and fixed column CreatedAt to appropriate fixed time.
Removed some extra rows (outdated) in user_file about information update.