### PR TITLE
Add more supported gamemodes (e.g. Relax, Autopilot, ScoreV2)

### DIFF
--- a/Server/API/Controllers/AuthController.cs
+++ b/Server/API/Controllers/AuthController.cs
@@ -28,7 +28,7 @@ public class AuthController : ControllerBase
 
         if (user == null)
             return BadRequest(new ErrorResponse("Invalid credentials"));
-        
+
         if (user.IsRestricted)
             return BadRequest(new ErrorResponse("Your account is restricted"));
 
@@ -55,7 +55,7 @@ public class AuthController : ControllerBase
     {
         if (!ModelState.IsValid || request == null)
             return BadRequest(new ErrorResponse("One or more required fields are missing."));
-        
+
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
         var user = await database.UserService.GetUser(username: request.Username);
 
@@ -83,8 +83,6 @@ public class AuthController : ControllerBase
 
         var location = await RegionHelper.GetRegion(RegionHelper.GetUserIpAddress(Request));
 
-        Console.WriteLine(location.Ip);
-        
         if (Configuration.BannedIps.Contains(location.Ip))
             return BadRequest(new ErrorResponse("Your IP address is banned."));
 

--- a/Server/API/Controllers/BeatmapController.cs
+++ b/Server/API/Controllers/BeatmapController.cs
@@ -66,7 +66,7 @@ public class BeatmapController : ControllerBase
 
         var scores = await database.ScoreService.GetBeatmapScores(beatmap.Checksum, modeEnum, modsEnum == Mods.None ? LeaderboardType.Global : LeaderboardType.GlobalWithMods, modsEnum);
 
-        var limitedScores = scores.SortScoresByTotalScore().Take(limit).Select(score => new ScoreResponse(score, database.UserService.GetUser(score.UserId).Result)).ToList();
+        var limitedScores = scores.SortScoresByTheirScoreValue().Take(limit).Select(score => new ScoreResponse(score, database.UserService.GetUser(score.UserId).Result)).ToList();
         return Ok(new ScoresResponse(limitedScores, scores.Count));
     }
 

--- a/Server/API/Controllers/BeatmapController.cs
+++ b/Server/API/Controllers/BeatmapController.cs
@@ -9,6 +9,7 @@ using Sunrise.Server.Extensions;
 using Sunrise.Server.Managers;
 using Sunrise.Server.Types.Enums;
 using AuthService = Sunrise.Server.API.Services.AuthService;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.API.Controllers;
 

--- a/Server/API/Controllers/ScoreController.cs
+++ b/Server/API/Controllers/ScoreController.cs
@@ -1,11 +1,11 @@
 using Microsoft.AspNetCore.Mvc;
-using osu.Shared;
 using Sunrise.Server.API.Managers;
 using Sunrise.Server.API.Serializable.Response;
 using Sunrise.Server.Application;
 using Sunrise.Server.Attributes;
 using Sunrise.Server.Database;
 using Sunrise.Server.Objects;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.API.Controllers;
 
@@ -61,7 +61,8 @@ public class ScoreController : ControllerBase
     {
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
 
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         if (limit is < 1 or > 100) return BadRequest(new ErrorResponse("Invalid limit parameter"));
 

--- a/Server/API/Controllers/UserController.cs
+++ b/Server/API/Controllers/UserController.cs
@@ -1,7 +1,5 @@
 using System.Text.Json;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using osu.Shared;
 using Sunrise.Server.API.Managers;
 using Sunrise.Server.API.Serializable.Request;
 using Sunrise.Server.API.Serializable.Response;
@@ -15,6 +13,7 @@ using Sunrise.Server.Services;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Utils;
 using AuthService = Sunrise.Server.API.Services.AuthService;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.API.Controllers;
 
@@ -54,7 +53,6 @@ public class UserController : ControllerBase
         if (mode == null) return Ok(new UserResponse(user, userStatus));
 
         var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
-
         if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         var stats = await database.UserService.Stats.GetUserStats(id, (GameMode)mode);
@@ -110,7 +108,8 @@ public class UserController : ControllerBase
     [Route("{id:int}/graph")]
     public async Task<IActionResult> GetUserGraphData(int id, [FromQuery(Name = "mode")] int mode)
     {
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
         var userStats = await database.UserService.Stats.GetUserStats(id, (GameMode)mode);
@@ -145,7 +144,8 @@ public class UserController : ControllerBase
     {
         if (scoresType is < 0 or > 2 or null) return BadRequest(new ErrorResponse("Invalid scores type parameter"));
 
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         if (limit is < 1 or > 100) return BadRequest(new ErrorResponse("Invalid limit parameter"));
 
@@ -170,7 +170,8 @@ public class UserController : ControllerBase
         [FromQuery(Name = "limit")] int? limit = 15,
         [FromQuery(Name = "page")] int? page = 0)
     {
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         if (limit is < 1 or > 100) return BadRequest(new ErrorResponse("Invalid limit parameter"));
 
@@ -236,7 +237,8 @@ public class UserController : ControllerBase
         if (leaderboardType is < 0 or > 1 or null)
             return BadRequest(new ErrorResponse("Invalid leaderboard type parameter"));
 
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         if (limit is < 1 or > 100) return BadRequest(new ErrorResponse("Invalid limit parameter"));
 
@@ -341,7 +343,8 @@ public class UserController : ControllerBase
     public async Task<IActionResult> GetUserMedals(int id,
         [FromQuery(Name = "mode")] int mode)
     {
-        if (mode is < 0 or > 3) return BadRequest(new ErrorResponse("Invalid mode parameter"));
+        var isValidMode = Enum.IsDefined(typeof(GameMode), (byte)mode);
+        if (isValidMode != true) return BadRequest(new ErrorResponse("Invalid mode parameter"));
 
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
 
@@ -401,7 +404,7 @@ public class UserController : ControllerBase
         var session = await Request.GetSessionFromRequest();
         if (session == null)
             return Unauthorized(new ErrorResponse("Invalid session"));
-        
+
         if (!ModelState.IsValid || request == null)
             return BadRequest(new ErrorResponse("One or more required fields are missing."));
 

--- a/Server/API/Serializable/Response/ScoreResponse.cs
+++ b/Server/API/Serializable/Response/ScoreResponse.cs
@@ -3,7 +3,7 @@ using Sunrise.Server.Database.Models;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Extensions;
 using Sunrise.Server.Utils;
-using GameMode = Sunrise.Server.Types.Enums.GameMode;
+using GameMode = osu.Shared.GameMode;
 
 namespace Sunrise.Server.API.Serializable.Response;
 
@@ -34,7 +34,7 @@ public class ScoreResponse(Score score, User user)
     public int CountMiss { get; set; } = score.CountMiss;
 
     [JsonPropertyName("game_mode")]
-    public GameMode GameMode { get; set; } = score.GameMode;
+    public GameMode GameMode { get; set; } = score.GameMode.ToVanillaGameMode();
 
     [JsonPropertyName("grade")]
     public string Grade { get; set; } = score.Grade;

--- a/Server/API/Serializable/Response/ScoreResponse.cs
+++ b/Server/API/Serializable/Response/ScoreResponse.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
-using osu.Shared;
 using Sunrise.Server.Database.Models;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Extensions;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.API.Serializable.Response;
 

--- a/Server/API/Serializable/Response/UserStatsResponse.cs
+++ b/Server/API/Serializable/Response/UserStatsResponse.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
-using osu.Shared;
 using Sunrise.Server.Database.Models.User;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.API.Serializable.Response;
 

--- a/Server/Application/BackgroundTasks.cs
+++ b/Server/Application/BackgroundTasks.cs
@@ -31,7 +31,7 @@ public static class BackgroundTasks
 
                 rankSnapshots.Sort((a, b) => a.SavedAt.CompareTo(b.SavedAt));
 
-                if (rankSnapshots.Count >= 70) rankSnapshots = rankSnapshots[..68];
+                if (rankSnapshots.Count >= 70) rankSnapshots = rankSnapshots[1..]; // Remove the oldest snapshot
 
                 rankSnapshots.Add(new StatsSnapshot
                 {

--- a/Server/Application/BackgroundTasks.cs
+++ b/Server/Application/BackgroundTasks.cs
@@ -1,9 +1,9 @@
 using System.IO.Compression;
 using Hangfire;
-using osu.Shared;
 using Sunrise.Server.Database;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Types.Enums;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Application;
 
@@ -20,9 +20,9 @@ public static class BackgroundTasks
     {
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
 
-        for (var i = 0; i < 4; i++)
+        foreach (var i in Enum.GetValues<GameMode>())
         {
-            var usersStats = await database.UserService.Stats.GetAllUserStats((GameMode)i, LeaderboardSortType.Pp);
+            var usersStats = await database.UserService.Stats.GetAllUserStats(i, LeaderboardSortType.Pp);
 
             foreach (var stats in usersStats)
             {

--- a/Server/Chat/Commands/BestCommand.cs
+++ b/Server/Chat/Commands/BestCommand.cs
@@ -34,7 +34,7 @@ public class BestCommand : IChatCommand
             userId = user.Id;
         }
 
-        var scores = await database.ScoreService.GetUserScores(userId, session.Attributes.Status.PlayMode, ScoreTableType.Best);
+        var scores = await database.ScoreService.GetUserScores(userId, (GameMode)session.Attributes.Status.PlayMode, ScoreTableType.Best);
 
         var bestScores = scores.OrderByDescending(x => x.PerformancePoints).Take(5).ToList();
 

--- a/Server/Chat/Commands/Development/AppendNewUserStats.cs
+++ b/Server/Chat/Commands/Development/AppendNewUserStats.cs
@@ -1,0 +1,79 @@
+using Sunrise.Server.Application;
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Database;
+using Sunrise.Server.Database.Models.User;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Attributes;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Types.Interfaces;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
+
+namespace Sunrise.Server.Chat.Commands.Development;
+
+[ChatCommand("appendnewuserstats", requiredPrivileges: UserPrivileges.Developer)]
+public class AppendNewUserStats : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (Configuration.OnMaintenance)
+        {
+            CommandRepository.SendMessage(session, "Server is in maintenance mode. Starting new user stats appending is not possible.");
+            return Task.CompletedTask;
+        }
+
+        CommandRepository.SendMessage(session,
+            "Appending new user stats if needed has been started. Server is in maintenance mode.");
+
+        Configuration.OnMaintenance = true;
+
+        _ = AppendMissingUserStats(session);
+        return Task.CompletedTask;
+    }
+
+    private async Task AppendMissingUserStats(Session session)
+    {
+        var sessions = ServicesProviderHolder.GetRequiredService<SessionRepository>();
+
+        foreach (var userSession in sessions.GetSessions())
+        {
+            userSession.SendBanchoMaintenance();
+        }
+
+        var startTime = DateTime.UtcNow;
+
+        var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
+
+        var users = await database.UserService.GetAllUsers();
+
+        foreach (var mode in Enum.GetValues<GameMode>())
+        {
+            foreach (var user in users)
+            {
+                var stats = await database.UserService.Stats.GetUserStats(user.Id, mode);
+
+                if (stats != null)
+                {
+                    continue;
+                }
+
+                var newStats = new UserStats
+                {
+                    UserId = user.Id,
+                    GameMode = mode
+                };
+
+                await database.UserService.Stats.InsertUserStats(newStats);
+
+                CommandRepository.SendMessage(session,
+                    $"User {user.Id} stats for mode {mode} has been created.");
+            }
+
+            CommandRepository.SendMessage(session, $"Rechecking {mode} mode is finished. Took {(DateTime.UtcNow - startTime).TotalSeconds} seconds.");
+        }
+
+        Configuration.OnMaintenance = false;
+
+        CommandRepository.SendMessage(session, "Appending new user stats if needed has been finished. Server is back online.");
+    }
+}

--- a/Server/Chat/Commands/Development/AppendNewUserStatsCommand.cs
+++ b/Server/Chat/Commands/Development/AppendNewUserStatsCommand.cs
@@ -12,7 +12,7 @@ using GameMode = Sunrise.Server.Types.Enums.GameMode;
 namespace Sunrise.Server.Chat.Commands.Development;
 
 [ChatCommand("appendnewuserstats", requiredPrivileges: UserPrivileges.Developer)]
-public class AppendNewUserStats : IChatCommand
+public class AppendNewUserStatsCommand : IChatCommand
 {
     public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {

--- a/Server/Chat/Commands/Development/BackupDatabaseCommand.cs
+++ b/Server/Chat/Commands/Development/BackupDatabaseCommand.cs
@@ -1,0 +1,37 @@
+using Sunrise.Server.Application;
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories.Attributes;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Chat.Commands.Development;
+
+[ChatCommand("backupdatabase", requiredPrivileges: UserPrivileges.Developer)]
+public class BackupDatabaseCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (Configuration.OnMaintenance)
+        {
+            CommandRepository.SendMessage(session, "Server is in maintenance mode. Starting database backup is not possible.");
+            return Task.CompletedTask;
+        }
+
+        CommandRepository.SendMessage(session, "Database backup has been started. Server is in maintenance mode.");
+
+        Configuration.OnMaintenance = true;
+
+        _ = StartDatabaseBackup(session);
+
+        return Task.CompletedTask;
+    }
+
+    private Task StartDatabaseBackup(Session session)
+    {
+        BackgroundTasks.BackupDatabase();
+        CommandRepository.SendMessage(session, "Database backup has been completed. Server is no longer in maintenance mode.");
+        Configuration.OnMaintenance = false;
+        return Task.CompletedTask;
+    }
+}

--- a/Server/Chat/Commands/Development/RecalculateCommand.cs
+++ b/Server/Chat/Commands/Development/RecalculateCommand.cs
@@ -1,4 +1,3 @@
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Attributes;
 using Sunrise.Server.Database;
@@ -8,6 +7,7 @@ using Sunrise.Server.Repositories.Attributes;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Types.Interfaces;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Chat.Commands.Development;
 

--- a/Server/Chat/Commands/Development/SaveStatsSnapshotCommand.cs
+++ b/Server/Chat/Commands/Development/SaveStatsSnapshotCommand.cs
@@ -1,0 +1,36 @@
+using Sunrise.Server.Application;
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories.Attributes;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Chat.Commands.Development;
+
+[ChatCommand("savestatssnapshot", requiredPrivileges: UserPrivileges.Developer)]
+public class SaveStatsSnapshotCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (Configuration.OnMaintenance)
+        {
+            CommandRepository.SendMessage(session, "Server is in maintenance mode. Save stats snapshot is not possible.");
+            return Task.CompletedTask;
+        }
+
+        CommandRepository.SendMessage(session, "Saving stats snapshot has been started. Server is in maintenance mode.");
+
+        Configuration.OnMaintenance = true;
+
+        _ = StartSaveStatsSnapshot(session);
+        return Task.CompletedTask;
+    }
+
+    private async Task StartSaveStatsSnapshot(Session session)
+    {
+        await BackgroundTasks.SaveStatsSnapshot();
+
+        CommandRepository.SendMessage(session, "Saving stats snapshot has been completed. Server is no longer in maintenance mode.");
+        Configuration.OnMaintenance = false;
+    }
+}

--- a/Server/Chat/Commands/Development/UpdateUsersBestComboCommand.cs
+++ b/Server/Chat/Commands/Development/UpdateUsersBestComboCommand.cs
@@ -1,4 +1,3 @@
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Attributes;
 using Sunrise.Server.Database;
@@ -7,6 +6,7 @@ using Sunrise.Server.Repositories;
 using Sunrise.Server.Repositories.Attributes;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Types.Interfaces;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Chat.Commands.Development;
 
@@ -47,7 +47,6 @@ public class UpdateUsersBestComboCommand : IChatCommand
         {
             var allScores = await database.ScoreService.GetBestScoresByGameMode(mode);
             var groupedScores = allScores.Where(x => x.IsScoreable).GroupBy(x => x.UserId);
-
 
             foreach (var group in groupedScores)
             {

--- a/Server/Chat/Commands/Moderation/RestrictCommand.cs
+++ b/Server/Chat/Commands/Moderation/RestrictCommand.cs
@@ -1,4 +1,3 @@
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Attributes;
 using Sunrise.Server.Database;
@@ -7,6 +6,7 @@ using Sunrise.Server.Repositories.Attributes;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Types.Interfaces;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Chat.Commands.Moderation;
 
@@ -54,8 +54,8 @@ public class RestrictCommand : IChatCommand
         await database.UserService.Moderation.RestrictPlayer(user.Id, session.User.Id, reason);
 
         var isRestricted = await database.UserService.Moderation.IsRestricted(user.Id);
-        
-        for (var i = 0; i < 4; i++)
+
+        foreach (var i in Enum.GetValues(typeof(GameMode)))
         {
             var stat = await database.UserService.Stats.GetUserStats(user.Id, (GameMode)i);
             var pp = await Calculators.CalculateUserWeightedPerformance(user.Id, (GameMode)i);
@@ -66,7 +66,7 @@ public class RestrictCommand : IChatCommand
 
             await database.UserService.Stats.UpdateUserStats(stat);
         }
-        
+
         CommandRepository.SendMessage(session,
             isRestricted
                 ? $"User {user.Username} ({user.Id}) has been restricted."

--- a/Server/Chat/Commands/Moderation/UnrestrictCommand.cs
+++ b/Server/Chat/Commands/Moderation/UnrestrictCommand.cs
@@ -1,4 +1,3 @@
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Attributes;
 using Sunrise.Server.Database;
@@ -7,6 +6,7 @@ using Sunrise.Server.Repositories.Attributes;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Types.Interfaces;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Chat.Commands.Moderation;
 
@@ -44,8 +44,8 @@ public class UnrestrictCommand : IChatCommand
         }
 
         await database.UserService.Moderation.UnrestrictPlayer(user.Id);
-        
-        for (var i = 0; i < 4; i++)
+
+        foreach (var i in Enum.GetValues(typeof(GameMode)))
         {
             var stat = await database.UserService.Stats.GetUserStats(user.Id, (GameMode)i);
             var pp = await Calculators.CalculateUserWeightedPerformance(user.Id, (GameMode)i);

--- a/Server/Controllers/ScoreController.cs
+++ b/Server/Controllers/ScoreController.cs
@@ -6,6 +6,7 @@ using Sunrise.Server.Repositories;
 using Sunrise.Server.Services;
 using Sunrise.Server.Types.Enums;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Controllers;
 
@@ -39,8 +40,15 @@ public class ScoreController : ControllerBase
         if (!sessions.TryGetSession(username, passhash, out var session) || session == null)
             return Ok("error: pass");
 
-        var result = await ScoreService.SubmitScore(session, scoreSerialized, beatmapHash, scoreTime, scoreFailTime,
-            osuVersion, clientHash, replayFile, storyboardHash);
+        var result = await ScoreService.SubmitScore(session,
+            scoreSerialized,
+            beatmapHash,
+            scoreTime,
+            scoreFailTime,
+            osuVersion,
+            clientHash,
+            replayFile,
+            storyboardHash);
         return await Task.FromResult<IActionResult>(Ok(result));
     }
 

--- a/Server/Database/Database.cs
+++ b/Server/Database/Database.cs
@@ -1,5 +1,4 @@
 ﻿using DatabaseWrapper.Core;
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Database.Models;
 using Sunrise.Server.Database.Models.User;
@@ -11,6 +10,7 @@ using Sunrise.Server.Managers;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Types.Enums;
 using Watson.ORM.Sqlite;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database;
 
@@ -90,7 +90,7 @@ public sealed class DatabaseManager
         _redis.FlushAllCache();
         _logger.LogInformation("Cache flushed. Rebuilding user ranks...");
 
-        for (var i = 0; i < 4; i++)
+        foreach (var i in Enum.GetValues(typeof(GameMode)))
         {
             UserService.Stats.SetAllUserRanks((GameMode)i).Wait();
         }

--- a/Server/Database/Models/Medal.cs
+++ b/Server/Database/Models/Medal.cs
@@ -1,13 +1,14 @@
-﻿using osu.Shared;
-using Sunrise.Server.Types.Enums;
+﻿using Sunrise.Server.Types.Enums;
 using Watson.ORM.Core;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Models;
 
 [Table("medal")]
 public class Medal
 {
-    [Column(true, DataTypes.Int, false)] public int Id { get; set; }
+    [Column(true, DataTypes.Int, false)]
+    public int Id { get; set; }
 
     [Column(DataTypes.Nvarchar, 1024, false)]
     public string Name { get; set; }
@@ -15,13 +16,17 @@ public class Medal
     [Column(DataTypes.Nvarchar, 1024, false)]
     public string Description { get; set; }
 
-    [Column(DataTypes.Int)] public GameMode? GameMode { get; set; }
+    [Column(DataTypes.Int)]
+    public GameMode? GameMode { get; set; }
 
-    [Column(DataTypes.Int, false)] public MedalCategory Category { get; set; }
+    [Column(DataTypes.Int, false)]
+    public MedalCategory Category { get; set; }
 
-    [Column(DataTypes.Nvarchar, 1024)] public string? FileUrl { get; set; }
+    [Column(DataTypes.Nvarchar, 1024)]
+    public string? FileUrl { get; set; }
 
-    [Column(DataTypes.Int)] public int FileId { get; set; }
+    [Column(DataTypes.Int)]
+    public int FileId { get; set; }
 
     [Column(DataTypes.Nvarchar, 1024, false)]
     public string Condition { get; set; }

--- a/Server/Database/Models/Score.cs
+++ b/Server/Database/Models/Score.cs
@@ -1,7 +1,9 @@
 using osu.Shared;
+using Sunrise.Server.Extensions;
 using Sunrise.Server.Types.Enums;
 using Watson.ORM.Core;
 using SubmissionStatus = Sunrise.Server.Types.Enums.SubmissionStatus;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Models;
 
@@ -115,7 +117,7 @@ public class LocalProperties
     public LocalProperties FromScore(Score score)
     {
         SerializedMods = score.Mods & ~Mods.Nightcore;
-        IsRanked = score.BeatmapStatus is BeatmapStatus.Ranked or BeatmapStatus.Approved;
+        IsRanked = score.BeatmapStatus.IsRanked();
         LeaderboardPosition = -1;
         return this;
     }

--- a/Server/Database/Models/User/UserStats.cs
+++ b/Server/Database/Models/User/UserStats.cs
@@ -1,5 +1,5 @@
-﻿using osu.Shared;
-using Watson.ORM.Core;
+﻿using Watson.ORM.Core;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Models.User;
 

--- a/Server/Database/Models/User/UserStatsSnapshot.cs
+++ b/Server/Database/Models/User/UserStatsSnapshot.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json;
-using osu.Shared;
 using Watson.ORM.Core;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Models.User;
 

--- a/Server/Database/Services/MedalService.cs
+++ b/Server/Database/Services/MedalService.cs
@@ -1,10 +1,10 @@
 using ExpressionTree;
-using osu.Shared;
 using Sunrise.Server.Database.Models;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Storages;
 using Sunrise.Server.Types;
 using Watson.ORM.Sqlite;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Services;
 

--- a/Server/Database/Services/Score/ScoreService.cs
+++ b/Server/Database/Services/Score/ScoreService.cs
@@ -60,7 +60,7 @@ public class ScoreService
             if (scoreUser?.IsRestricted == true) scores.Remove(score);
         }
 
-        return scores.GetScoresGroupedByBeatmapBest().SortScoresByPerformancePoints();
+        return scores.GetScoresGroupedByUsersBest().SortScoresByPerformancePoints();
     }
 
     public async Task<Models.Score?> GetScore(int id)

--- a/Server/Database/Services/Score/ScoreService.cs
+++ b/Server/Database/Services/Score/ScoreService.cs
@@ -8,6 +8,7 @@ using Sunrise.Server.Types;
 using Sunrise.Server.Types.Enums;
 using Watson.ORM.Sqlite;
 using SubmissionStatus = Sunrise.Server.Types.Enums.SubmissionStatus;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Services.Score;
 
@@ -52,7 +53,7 @@ public class ScoreService
             .PrependAnd("SubmissionStatus", OperatorEnum.Equals, (int)SubmissionStatus.Best);
 
         var scores = await _database.SelectManyAsync<Models.Score>(exp);
-      
+
         foreach (var score in scores.ToList())
         {
             var scoreUser = await _services.UserService.GetUser(score.UserId);
@@ -80,7 +81,7 @@ public class ScoreService
     {
         var user = await _services.UserService.GetUser(userId);
         if (user.IsRestricted) return [];
-      
+
         var exp = new Expr("UserId", OperatorEnum.Equals, userId)
             .PrependAnd("GameMode", OperatorEnum.Equals, (int)mode);
 
@@ -135,7 +136,7 @@ public class ScoreService
     {
         var user = await _services.UserService.GetUser(userId);
         if (user.IsRestricted) return [];
-      
+
         var exp = new Expr("UserId", OperatorEnum.Equals, userId)
             .PrependAnd("GameMode", OperatorEnum.Equals, (int)mode);
 

--- a/Server/Database/Services/Score/ScoreService.cs
+++ b/Server/Database/Services/Score/ScoreService.cs
@@ -162,7 +162,7 @@ public class ScoreService
                 scoreUser?.IsRestricted == true) scores.Remove(score);
         }
 
-        return scores.SortScoresByTotalScore();
+        return scores.SortScoresByTheirScoreValue();
     }
 
     public async Task<List<Models.Score>> GetUserScores(int userId, GameMode mode, ScoreTableType type)

--- a/Server/Database/Services/User/Services/UserMedalsService.cs
+++ b/Server/Database/Services/User/Services/UserMedalsService.cs
@@ -1,9 +1,9 @@
 using ExpressionTree;
-using osu.Shared;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Types;
 using Watson.ORM.Sqlite;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Services.User.Services;
 

--- a/Server/Database/Services/User/Services/UserStatsSnapshotService.cs
+++ b/Server/Database/Services/User/Services/UserStatsSnapshotService.cs
@@ -1,9 +1,9 @@
 using ExpressionTree;
-using osu.Shared;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Types;
 using Watson.ORM.Sqlite;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Services.User.Services;
 

--- a/Server/Database/Services/User/UserService.cs
+++ b/Server/Database/Services/User/UserService.cs
@@ -1,11 +1,11 @@
 using ExpressionTree;
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Database.Services.User.Services;
 using Sunrise.Server.Repositories;
 using Sunrise.Server.Types;
 using Watson.ORM.Sqlite;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Database.Services.User;
 
@@ -110,7 +110,7 @@ public class UserService
 
         if (session != null)
             await session.UpdateUser(user);
-        
+
         await _redis.Remove(RedisKey.AllUsers());
 
         await _redis.Set(
@@ -120,7 +120,7 @@ public class UserService
             ],
             user);
     }
-    
+
     public async Task<List<Models.User.User>?> GetAllUsers(bool useCache = true)
     {
         var cachedStats = await _redis.Get<List<Models.User.User>>(RedisKey.AllUsers());

--- a/Server/Extensions/BeatmapStatusExtensions.cs
+++ b/Server/Extensions/BeatmapStatusExtensions.cs
@@ -1,0 +1,11 @@
+using Sunrise.Server.Types.Enums;
+
+namespace Sunrise.Server.Extensions;
+
+public static class BeatmapStatusExtensions
+{
+    public static bool IsRanked(this BeatmapStatus status)
+    {
+        return status is BeatmapStatus.Ranked or BeatmapStatus.Approved;
+    }
+}

--- a/Server/Extensions/GameModeExtensions.cs
+++ b/Server/Extensions/GameModeExtensions.cs
@@ -36,4 +36,12 @@ public static class GameModeExtensions
 
         return mode;
     }
+
+    public static bool IsGameModeWithoutScoreMultiplier(this GameMode mode)
+    {
+        var isRelax = mode is GameMode.RelaxStandard or GameMode.RelaxTaiko or GameMode.RelaxCatchTheBeat;
+        var isAutopilot = mode == GameMode.AutopilotStandard;
+
+        return isRelax || isAutopilot;
+    }
 }

--- a/Server/Extensions/GameModeExtensions.cs
+++ b/Server/Extensions/GameModeExtensions.cs
@@ -25,7 +25,7 @@ public static class GameModeExtensions
                 case Mods.Relax:
                     mode += 4;
                     break;
-                case Mods.Autoplay:
+                case Mods.Relax2:
                     mode += 8;
                     break;
             }

--- a/Server/Extensions/GameModeExtensions.cs
+++ b/Server/Extensions/GameModeExtensions.cs
@@ -1,0 +1,39 @@
+using osu.Shared;
+using Sunrise.Server.Helpers;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
+
+namespace Sunrise.Server.Extensions;
+
+public static class GameModeExtensions
+{
+    public static osu.Shared.GameMode ToVanillaGameMode(this GameMode mode)
+    {
+        return (osu.Shared.GameMode)((int)mode % 4);
+    }
+
+    public static GameMode EnrichWithMods(this GameMode mode, Mods mods)
+    {
+        var gamemodeMode = SubmitScoreHelper.TryGetSelectedNotStandardMods(mods);
+
+        if (gamemodeMode != Mods.None)
+        {
+            switch (gamemodeMode)
+            {
+                case Mods.ScoreV2:
+                    mode += 12;
+                    break;
+                case Mods.Relax:
+                    mode += 4;
+                    break;
+                case Mods.Autoplay:
+                    mode += 8;
+                    break;
+            }
+        }
+
+        if (!Enum.IsDefined(typeof(GameMode), mode))
+            mode = (GameMode)mode.ToVanillaGameMode();
+
+        return mode;
+    }
+}

--- a/Server/Extensions/ScoreExtensions.cs
+++ b/Server/Extensions/ScoreExtensions.cs
@@ -5,6 +5,7 @@ using Sunrise.Server.Database.Models;
 using Sunrise.Server.Objects;
 using Sunrise.Server.Objects.Serializable;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Extensions;
 
@@ -82,12 +83,13 @@ public static class ScoreExtensions
     {
         var leaderboard = GetScoresGroupedByUsersBest(scores);
 
-        var oldScores = leaderboard.FindAll(x => x.UserId == score.UserId && x.BeatmapHash == score.BeatmapHash && x.GameMode == score.GameMode); 
+        var oldScores = leaderboard.FindAll(x => x.UserId == score.UserId && x.BeatmapHash == score.BeatmapHash && x.GameMode == score.GameMode);
+
         foreach (var oldScore in oldScores)
         {
             scores.Remove(oldScore);
         }
-        
+
         leaderboard.Add(score);
         leaderboard = GetScoresGroupedByUsersBest(leaderboard);
         leaderboard = leaderboard.SortScoresByTotalScore();
@@ -130,6 +132,7 @@ public static class ScoreExtensions
 
         score.Accuracy = Calculators.CalculateAccuracy(score);
         score.PerformancePoints = Calculators.CalculatePerformancePoints(session, score);
+        score.GameMode = score.GameMode.EnrichWithMods(score.Mods);
 
         return score;
     }
@@ -173,7 +176,7 @@ public static class ScoreExtensions
             score.Grade,
             (int)score.Mods,
             score.IsPassed,
-            (int)score.GameMode,
+            (int)score.GameMode.ToVanillaGameMode(),
             score.ClientTime,
             score.OsuVersion,
             clientHash,

--- a/Server/Extensions/ScoreExtensions.cs
+++ b/Server/Extensions/ScoreExtensions.cs
@@ -40,7 +40,7 @@ public static class ScoreExtensions
         return GroupScoresByUserId(scores)
             .Select(x => x.ToList()
                 .GroupScoresByBeatmapId()
-                .Select(y => y.OrderByDescending(z => z.TotalScore)
+                .Select(y => y.OrderByDescending(z => z.GameMode.IsGameModeWithoutScoreMultiplier() ? z.PerformancePoints : z.TotalScore)
                     .First()))
             .SelectMany(x => x)
             .ToList();
@@ -48,7 +48,7 @@ public static class ScoreExtensions
 
     public static List<T> GetScoresGroupedByBeatmapBest<T>(this List<T> scores) where T : Score
     {
-        return GroupScoresByBeatmapId(scores).Select(x => x.OrderByDescending(y => y.TotalScore).First()).ToList();
+        return GroupScoresByBeatmapId(scores).Select(x => x.OrderByDescending(y => y.GameMode.IsGameModeWithoutScoreMultiplier() ? y.PerformancePoints : y.TotalScore).First()).ToList();
     }
 
     public static IEnumerable<IGrouping<int, T>> GroupScoresByBeatmapId<T>(this List<T> scores) where T : Score
@@ -79,6 +79,24 @@ public static class ScoreExtensions
         return scores;
     }
 
+    /// <summary>
+    ///     Sorts the scores by their score value.
+    ///     Score value is determined if the game mode has a score multiplier or not.
+    ///     For game modes with score multiplier, the scores are sorted by their total score.
+    ///     For game modes without score multiplier, the scores are sorted by their performance points.
+    /// </summary>
+    /// <param name="scores"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static List<T> SortScoresByTheirScoreValue<T>(this List<T> scores) where T : Score
+    {
+        var isWithoutScoreMultiplier = scores.FirstOrDefault()?.GameMode.IsGameModeWithoutScoreMultiplier() ?? false;
+
+        return isWithoutScoreMultiplier
+            ? scores.SortScoresByPerformancePoints()
+            : scores.SortScoresByTotalScore();
+    }
+
     public static List<T> UpsertUserScoreToSortedScores<T>(this List<T> scores, T score) where T : Score
     {
         var leaderboard = GetScoresGroupedByUsersBest(scores);
@@ -92,7 +110,7 @@ public static class ScoreExtensions
 
         leaderboard.Add(score);
         leaderboard = GetScoresGroupedByUsersBest(leaderboard);
-        leaderboard = leaderboard.SortScoresByTotalScore();
+        leaderboard = leaderboard.SortScoresByTheirScoreValue();
         leaderboard = leaderboard.UpdateLeaderboardPositions();
 
         return leaderboard.ToList();
@@ -147,6 +165,12 @@ public static class ScoreExtensions
         return scores;
     }
 
+
+    /// <summary>
+    ///     Used in leaderboard responses.
+    /// </summary>
+    /// <param name="score"></param>
+    /// <returns></returns>
     public static async Task<string> GetString(this Score score)
     {
         var database = ServicesProviderHolder.GetRequiredService<DatabaseManager>();
@@ -155,8 +179,11 @@ public static class ScoreExtensions
         var username = (await database.UserService.GetUser(score.UserId))?.Username ?? "Unknown";
         var hasReplay = score.ReplayFileId != null ? "1" : "0";
 
+        // If the game mode is not scoreable, we should return the performance points instead of the total score
+        var totalScore = score.GameMode.IsGameModeWithoutScoreMultiplier() ? (int)score.PerformancePoints : score.TotalScore;
+
         return
-            $"{score.Id}|{username}|{score.TotalScore}|{score.MaxCombo}|{score.Count50}|{score.Count100}|{score.Count300}|{score.CountMiss}|{score.CountKatu}|{score.CountGeki}|{score.Perfect}|{(int)score.Mods}|{score.UserId}|{score.LocalProperties.LeaderboardPosition}|{time}|{hasReplay}";
+            $"{score.Id}|{username}|{totalScore}|{score.MaxCombo}|{score.Count50}|{score.Count100}|{score.Count300}|{score.CountMiss}|{score.CountKatu}|{score.CountGeki}|{score.Perfect}|{(int)score.Mods}|{score.UserId}|{score.LocalProperties.LeaderboardPosition}|{time}|{hasReplay}";
     }
 
     public static string ComputeOnlineHash(this Score score, string username, string clientHash, string? storyboardHash)

--- a/Server/Extensions/UserStatsExtensions.cs
+++ b/Server/Extensions/UserStatsExtensions.cs
@@ -2,6 +2,7 @@ using osu.Shared;
 using Sunrise.Server.Database.Models;
 using Sunrise.Server.Database.Models.User;
 using Sunrise.Server.Utils;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Extensions;
 

--- a/Server/Helpers/SubmitScoreHelper.cs
+++ b/Server/Helpers/SubmitScoreHelper.cs
@@ -91,9 +91,26 @@ public static class SubmitScoreHelper
 
     public static bool IsHasInvalidMods(Mods mods)
     {
-        // TODO: Support Relax and SCV2 at some point.
-        return mods.HasFlag(Mods.Relax) || mods.HasFlag(Mods.Autoplay) || mods.HasFlag(Mods.Target) ||
-               mods.HasFlag(Mods.ScoreV2);
+        return mods.HasFlag(Mods.Target);
+    }
+
+    /// <summary>
+    ///     This method checks if the score has any non-standard mods.
+    ///     If the score has any of the following mods, it will be considered as non-standard:
+    ///     <see cref="Mods.ScoreV2" />, <see cref="Mods.Relax" />, <see cref="Mods.Autoplay" />
+    /// </summary>
+    /// <param name="mods"></param>
+    /// <returns></returns>
+    public static Mods TryGetSelectedNotStandardMods(Mods mods)
+    {
+        Mods[] prioritizedMods =
+        [
+            Mods.ScoreV2,
+            Mods.Relax,
+            Mods.Autoplay
+        ];
+
+        return prioritizedMods.Where(mod => mods.HasFlag(mod)).Aggregate(Mods.None, (current, mod) => current | mod);
     }
 
     public static int GetTimeElapsed(Score score, int scoreTime, int scoreFailTime)

--- a/Server/Helpers/SubmitScoreHelper.cs
+++ b/Server/Helpers/SubmitScoreHelper.cs
@@ -97,7 +97,7 @@ public static class SubmitScoreHelper
     /// <summary>
     ///     This method checks if the score has any non-standard mods.
     ///     If the score has any of the following mods, it will be considered as non-standard:
-    ///     <see cref="Mods.ScoreV2" />, <see cref="Mods.Relax" />, <see cref="Mods.Autoplay" />
+    ///     <see cref="Mods.ScoreV2" />, <see cref="Mods.Relax" />, <see cref="Mods.Relax2" />
     /// </summary>
     /// <param name="mods"></param>
     /// <returns></returns>
@@ -107,7 +107,7 @@ public static class SubmitScoreHelper
         [
             Mods.ScoreV2,
             Mods.Relax,
-            Mods.Autoplay
+            Mods.Relax2
         ];
 
         return prioritizedMods.Where(mod => mods.HasFlag(mod)).Aggregate(Mods.None, (current, mod) => current | mod);

--- a/Server/Objects/UserAttributes.cs
+++ b/Server/Objects/UserAttributes.cs
@@ -1,10 +1,11 @@
 using HOPEless.Bancho.Objects;
-using osu.Shared;
 using Sunrise.Server.Application;
 using Sunrise.Server.Database;
 using Sunrise.Server.Database.Models.User;
+using Sunrise.Server.Extensions;
 using Sunrise.Server.Objects.Serializable;
 using Sunrise.Server.Types.Enums;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Objects;
 
@@ -55,7 +56,7 @@ public class UserAttributes
             CountryCode = byte.Parse((Country ?? User.Country).ToString()),
             Permissions = User.GetPrivilegeRank(), // FIXME: Chat color doesn't work
             Rank = (int)userRank,
-            PlayMode = GetCurrentGameMode(),
+            PlayMode = GetCurrentGameMode().ToVanillaGameMode(),
             UsesOsuClient = UsesOsuClient
         };
     }
@@ -89,7 +90,7 @@ public class UserAttributes
 
     public GameMode GetCurrentGameMode()
     {
-        return Status.PlayMode;
+        return ((GameMode)Status.PlayMode).EnrichWithMods(Status.CurrentMods);
     }
 
     public BanchoUserStatus GetPlayerStatus()

--- a/Server/Services/ScoreService.cs
+++ b/Server/Services/ScoreService.cs
@@ -32,9 +32,13 @@ public static class ScoreService
             return "error: no";
         }
 
-        // Disallow submitting scores with double not standard mods (e.g. ScoreV2 + Relax) or with which we are not supporting (e.g. shouldn't exist)
         var notStandardMods = SubmitScoreHelper.TryGetSelectedNotStandardMods(score.Mods);
-        if ((int)score.GameMode < 4 && notStandardMods is not Mods.None || !notStandardMods.IsSingleMod())
+
+        var isHasMoreThanOneNotStandardMod = !notStandardMods.IsSingleMod() && notStandardMods is not Mods.None;
+        var isNonSupportedNonStandardMod = (int)score.GameMode < 4 && notStandardMods is not Mods.None;
+
+        // Disallow submitting scores with double not standard mods (e.g. ScoreV2 + Relax) or with which we are not supporting (e.g. shouldn't exist)
+        if (isHasMoreThanOneNotStandardMod || isNonSupportedNonStandardMod)
         {
             SubmitScoreHelper.ReportRejectionToMetrics(session, scoreSerialized, "Includes non-standard mod(s), which is not supported for this game mode");
             return "error: no";

--- a/Server/Types/Enums/GameMode.cs
+++ b/Server/Types/Enums/GameMode.cs
@@ -1,0 +1,20 @@
+﻿namespace Sunrise.Server.Types.Enums;
+
+public enum GameMode : byte
+{
+    Standard = 0,
+    Taiko = 1,
+    CatchTheBeat = 2,
+    Mania = 3,
+
+    RelaxStandard = 4,
+    RelaxTaiko = 5,
+    RelaxCatchTheBeat = 6,
+
+    AutopilotStandard = 8,
+
+    ScoreV2Standard = 12,
+    ScoreV2Taiko = 13,
+    ScoreV2CatchTheBeat = 14,
+    ScoreV2Mania = 15
+}

--- a/Server/Types/Enums/ModsShorted.cs
+++ b/Server/Types/Enums/ModsShorted.cs
@@ -14,9 +14,9 @@ public enum ModsShorted
     HT = 256,
     NC = 512,
     FL = 1024,
-    AP = 2048,
+    AT = 2048,
     SO = 4096,
-    R2 = 8192,
+    AP = 8192, // Relax2 -> AutoPilot -> AP
     PF = 16384,
     K4 = 32768,
     K5 = 65536,

--- a/Server/Types/RedisKey.cs
+++ b/Server/Types/RedisKey.cs
@@ -1,5 +1,5 @@
-using osu.Shared;
 using Sunrise.Server.Types.Enums;
+using GameMode = Sunrise.Server.Types.Enums.GameMode;
 
 namespace Sunrise.Server.Types;
 

--- a/Server/Utils/Calculators.cs
+++ b/Server/Utils/Calculators.cs
@@ -167,12 +167,12 @@ public static class Calculators
     {
         var totalHits = score.Count300 + score.Count100 + score.Count50 + score.CountMiss;
 
-        var scoreVanillaGameMode = score.GameMode.ToVanillaGameMode();
-        if ((GameMode)scoreVanillaGameMode == GameMode.Mania) totalHits += score.CountGeki + score.CountKatu;
+        var scoreVanillaGameMode = (GameMode)score.GameMode.ToVanillaGameMode();
+        if (scoreVanillaGameMode == GameMode.Mania) totalHits += score.CountGeki + score.CountKatu;
 
         if (totalHits == 0) return 0;
 
-        return (GameMode)scoreVanillaGameMode switch
+        return scoreVanillaGameMode switch
         {
             GameMode.Standard => (float)(score.Count300 * 300 + score.Count100 * 100 + score.Count50 * 50) /
                 (totalHits * 300) * 100,

--- a/Server/Utils/Parsers.cs
+++ b/Server/Utils/Parsers.cs
@@ -136,4 +136,9 @@ public static class Parsers
     {
         return (int)time.TotalSeconds;
     }
+
+    public static bool IsSingleMod(this Mods flags)
+    {
+        return flags != Mods.None && (flags & flags - 1) == 0;
+    }
 }


### PR DESCRIPTION
This PR is focused on adding more gamerules/gamemodes which are extended versions of their original gamemodes, but with drastically changed gameplay.

This gamemodes will be:

- Relax
- - Standard
- - Taiko
- - Catch the beat (cbt)
- Autopilot
- - Standard
- Score V2
- - Standard
- - Taiko
- - Catch the beat (cbt)
- - Mania

### Implementation
- I added new `GameMode enum` class, which copies the original, but with new gamemodes, so for each new gamemode will be created new user stats with their statistics
- On score parsing we will check if the user has only one of non-standard mods, and if it is, the gamemode of the score will be changed to reflect that. 
- On selecting non-standard mode in menu, we will fetch user stats for that gamemode
- While fetching the leaderboard with non-standard mod activated, we will fetch all the scores with that non-standard mod gamemode, example: Checking Global leaderboard with Relax mod active, will show only Relax scores
- For non-standard modes with no score multiplier, sort them in leaderboard by PP

### Other changes
- [fix: GetBestScoresByGameMode getting only by beatmap best, should be by users best](https://github.com/SunriseCommunity/Sunrise/pull/35/commits/df4114dc6e447d5ad0edb92cf3ecf739089e2177)
- [fix: Remove the oldest stats snapshot, not the newest](https://github.com/SunriseCommunity/Sunrise/pull/35/commits/50c911383c863c1594e8853e33728bc76bd66037)

- [feat: Add SaveStatsSnapshotCommand](https://github.com/SunriseCommunity/Sunrise/pull/35/commits/6e40cf825263fbc6d689bb60674e93d94318c6c4)
- [feat: Add BackupDatabaseCommand](https://github.com/SunriseCommunity/Sunrise/pull/35/commits/5abc486dfd7238e41c4c8feb52b20d3b79234e98)

### After merge 
- Use `!appendnewuserstats` on sunshine bot to create new user stats profile on the server, otherwise they will be created only on demand.