### PR TITLE
Add more dev commands

### DIFF
--- a/Sunrise.Server/Chat/Commands/Development/AnnounceCommand.cs
+++ b/Sunrise.Server/Chat/Commands/Development/AnnounceCommand.cs
@@ -1,0 +1,59 @@
+using Sunrise.Server.Application;
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories;
+using Sunrise.Server.Repositories.Attributes;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Chat.Commands.Development;
+
+[ChatCommand("announce", requiredPrivileges: UserPrivileges.Developer)]
+public class AnnounceCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length < 1)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}announce <mode> <message?>");
+            return Task.CompletedTask;
+        }
+
+        var messageMode = args[0];
+
+        if (messageMode != "custom" && messageMode != "restart")
+        {
+            CommandRepository.SendMessage(session, "Invalid mode. Available modes: custom, restart");
+            return Task.CompletedTask;
+        }
+
+        if (messageMode == "custom" && args.Length < 2)
+        {
+            CommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}announce custom <message>");
+            return Task.CompletedTask;
+        }
+
+        var message = string.Join(" ", args[1..]);
+
+        if (messageMode == "restart")
+        {
+            message = "Hello! Server is going down for a restart, it will take around a minute or two. You will be reconnected automatically." + "\n" +
+                      "While you wait, you can still continue to play, all your scores will be uploaded once the server is back online." + "\n" +
+                      "Thank you for your patience and playing on Sunrise! :)";
+        }
+        else if (message.Length is < 1 or > 2000)
+        {
+            CommandRepository.SendMessage(session, "Please don't yap too much. Keep it between 1 and 2000 characters.");
+            return Task.CompletedTask;
+        }
+
+        var sessions = ServicesProviderHolder.GetRequiredService<SessionRepository>();
+
+        foreach (var userSession in sessions.GetSessions())
+        {
+            CommandRepository.SendMessage(userSession, message);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/Sunrise.Server/Chat/Commands/Development/ReloadConfigCommand.cs
+++ b/Sunrise.Server/Chat/Commands/Development/ReloadConfigCommand.cs
@@ -1,0 +1,63 @@
+using Sunrise.Server.Application;
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Objects;
+using Sunrise.Server.Repositories.Attributes;
+using Sunrise.Server.Types.Enums;
+using Sunrise.Server.Types.Interfaces;
+
+namespace Sunrise.Server.Chat.Commands.Development;
+
+[ChatCommand("reloadconfig", requiredPrivileges: UserPrivileges.Developer)]
+public class ReloadConfigCommand : IChatCommand
+{
+    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        var prevConfig = Configuration.GetConfig().AsEnumerable().ToArray();
+
+        Configuration.GetConfig().Reload();
+
+        var newConfig = Configuration.GetConfig().AsEnumerable().ToArray();
+
+        var changes = new List<string>();
+
+        foreach (var prev in prevConfig)
+        {
+            var newConfigValue = newConfig.FirstOrDefault(x => x.Key == prev.Key);
+
+            if (newConfigValue.Key == null)
+            {
+                changes.Add($"Removed: {prev.Key}");
+            }
+            else if (newConfigValue.Value != prev.Value)
+            {
+                changes.Add($"Changed: {prev.Key} from {prev.Value} to {newConfigValue.Value}");
+            }
+        }
+
+        foreach (var newField in newConfig)
+        {
+            var prevConfigValue = prevConfig.FirstOrDefault(x => x.Key == newField.Key);
+
+            if (prevConfigValue.Key == null)
+            {
+                changes.Add($"Added: {newField.Key} with value {newField.Value}");
+            }
+        }
+
+        if (changes.Count == 0)
+        {
+            CommandRepository.SendMessage(session, "No changes detected.");
+        }
+        else
+        {
+            CommandRepository.SendMessage(session, "Changes detected:");
+
+            foreach (var change in changes)
+            {
+                CommandRepository.SendMessage(session, change);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
This pull request introduces two new chat commands to the `Sunrise.Server` project: `AnnounceCommand` and `ReloadConfigCommand`. These commands are designed to facilitate server announcements and configuration reloads, respectively.

### New Chat Commands:

* `AnnounceCommand`:
  - Implements a command to broadcast messages to all active sessions.
  - Supports two modes: "custom" for user-defined messages and "restart" for predefined restart messages.
  - Includes input validation to ensure proper usage and message length constraints.

* `ReloadConfigCommand`:
  - Implements a command to reload the server configuration.
  - Compares the previous and new configurations to identify and announce any changes.
  - Provides detailed feedback on added, removed, or modified configuration entries.
  - Currently works only if server is hosted on docker container.