### PR TITLE
Add websockets support (+Scalar API Docs)

### DIFF
--- a/Sunrise.API/Controllers/BaseController.cs
+++ b/Sunrise.API/Controllers/BaseController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Sunrise.API.Managers;
 using Sunrise.API.Serializable.Response;
@@ -12,10 +13,14 @@ namespace Sunrise.API.Controllers;
 
 [ApiController]
 [Subdomain("api")]
+[ProducesResponseType(StatusCodes.Status200OK)]
+[ProducesResponseType(typeof(ErrorResponse), StatusCodes.Status400BadRequest)]
 public class BaseController(IMemoryCache cache, SessionManager sessionManager, DatabaseService database, SessionRepository sessions) : ControllerBase
 {
     [HttpGet]
     [Route("/ping")]
+    [EndpointDescription("Basic ping endpoint")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
     public IActionResult Index()
     {
         return Ok("Sunrise API");
@@ -23,6 +28,8 @@ public class BaseController(IMemoryCache cache, SessionManager sessionManager, D
 
     [HttpGet]
     [Route("/limits")]
+    [EndpointDescription("Check current API limits")]
+    [ProducesResponseType(typeof(LimitsResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetLimits()
     {
         var key = RegionService.GetUserIpAddress(Request);
@@ -37,6 +44,8 @@ public class BaseController(IMemoryCache cache, SessionManager sessionManager, D
     [HttpGet]
     [Route("/status")]
     [ResponseCache(VaryByHeader = "User-Agent", Duration = 60)]
+    [EndpointDescription("Check server status")]
+    [ProducesResponseType(typeof(StatusResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetStatus([FromQuery(Name = "detailed")] bool detailed = false)
     {
         var usersOnline = sessions.GetSessions().Count;

--- a/Sunrise.API/Controllers/WebSocketController.cs
+++ b/Sunrise.API/Controllers/WebSocketController.cs
@@ -7,6 +7,7 @@ namespace Sunrise.API.Controllers;
 
 [Route("/ws")]
 [Subdomain("api")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class WebSocketController(WebSocketManager webSocketManager) : ControllerBase
 {
     public async Task Get(CancellationToken cancellationToken)

--- a/Sunrise.API/Controllers/WebSocketController.cs
+++ b/Sunrise.API/Controllers/WebSocketController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Sunrise.Shared.Attributes;
+using WebSocketManager = Sunrise.API.Managers.WebSocketManager;
+
+namespace Sunrise.API.Controllers;
+
+[Route("/ws")]
+[Subdomain("api")]
+public class WebSocketController(WebSocketManager webSocketManager) : ControllerBase
+{
+    public async Task Get(CancellationToken cancellationToken)
+    {
+        if (HttpContext.WebSockets.IsWebSocketRequest)
+        {
+            using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync();
+            await webSocketManager.HandleConnection(webSocket, cancellationToken);
+        }
+        else
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+    }
+}

--- a/Sunrise.API/Enums/WebSocketEventType.cs
+++ b/Sunrise.API/Enums/WebSocketEventType.cs
@@ -1,0 +1,6 @@
+﻿namespace Sunrise.API.Enums;
+
+public enum WebSocketEventType
+{
+    NewScoreSubmitted
+}

--- a/Sunrise.API/Managers/WebSocketClient.cs
+++ b/Sunrise.API/Managers/WebSocketClient.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using Sunrise.API.Objects;
+
+namespace Sunrise.API.Managers;
+
+public class WebSocketClient(WebSocket webSocket)
+{
+    private readonly ConcurrentQueue<WebSocketMessage> _wsMessagesToPush = new();
+    private Task? _pushMessagesTask;
+
+    public void PushMessage(WebSocketMessage message)
+    {
+        _wsMessagesToPush.Enqueue(message);
+    }
+
+    public async Task HandleClientMessageAsync(CancellationToken cancellationToken)
+    {
+        var tempBuffer = new byte[1024 * 4];
+        WebSocketReceiveResult receiveResult;
+
+        do
+        {
+            receiveResult = await webSocket.ReceiveAsync(new ArraySegment<byte>(tempBuffer), cancellationToken);
+            if (!receiveResult.CloseStatus.HasValue)
+                continue;
+
+            await webSocket.CloseAsync(receiveResult.CloseStatus.Value, receiveResult.CloseStatusDescription, cancellationToken);
+            return;
+        } while (!receiveResult.EndOfMessage && !cancellationToken.IsCancellationRequested);
+    }
+
+    public async Task ProcessWebSocketMessagesAsync(CancellationToken cancellationToken)
+    {
+        _pushMessagesTask = Task.Run(async () => await PushPendingMessagesAsync(cancellationToken), cancellationToken);
+
+        while (!cancellationToken.IsCancellationRequested && webSocket.State == WebSocketState.Open)
+        {
+            await HandleClientMessageAsync(cancellationToken);
+        }
+
+        await _pushMessagesTask;
+    }
+
+    public async Task PushPendingMessagesAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            if (_wsMessagesToPush.TryDequeue(out var message))
+            {
+                var messageBytes = Encoding.UTF8.GetBytes(message.Data);
+                await webSocket.SendAsync(messageBytes, WebSocketMessageType.Text, true, cancellationToken);
+            }
+
+            if (_wsMessagesToPush.Count == 0)
+            {
+                await Task.Delay(1000, cancellationToken);
+            }
+        }
+    }
+}

--- a/Sunrise.API/Managers/WebSocketManager.cs
+++ b/Sunrise.API/Managers/WebSocketManager.cs
@@ -1,0 +1,50 @@
+﻿using System.Net.WebSockets;
+using Sunrise.API.Objects;
+
+namespace Sunrise.API.Managers;
+
+public class WebSocketManager
+{
+    private readonly List<WebSocketClient> _clientConnections = [];
+    
+    public async Task HandleConnection(WebSocket webSocket, CancellationToken cancellationToken)
+    {
+        var connection = new WebSocketClient(webSocket);
+        AddClientConnection(connection);
+        try
+        {
+            await connection.ProcessWebSocketMessagesAsync(cancellationToken);
+        }
+        finally
+        {
+            RemoveClientConnection(connection);
+        }
+    }
+
+    public void BroadcastJsonAsync(WebSocketMessage message)
+    {
+        lock (_clientConnections)
+        {
+            if (_clientConnections.Count > 0)
+            {
+                Parallel.ForEach(_clientConnections, conn => conn.PushMessage(message));
+            }
+        }
+    }
+    
+    private void AddClientConnection(WebSocketClient connection)
+    {
+        lock (_clientConnections)
+        {
+            _clientConnections.Add(connection);
+        }
+    }
+
+    private void RemoveClientConnection(WebSocketClient connection)
+    {
+        lock (_clientConnections)
+        {
+            _clientConnections.Remove(connection);
+        }
+    }
+}

--- a/Sunrise.API/Objects/WebSocketMessage.cs
+++ b/Sunrise.API/Objects/WebSocketMessage.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json;
+using Sunrise.API.Enums;
+
+namespace Sunrise.API.Objects;
+
+public class WebSocketMessage(WebSocketEventType type, object message)
+{
+    private readonly object _message = message;
+    public WebSocketEventType MessageType { get; } = type;
+
+    public string Data => JsonSerializer.Serialize(new
+    {
+        type = MessageType,
+        data = _message
+    });
+}

--- a/Sunrise.API/Serializable/Response/ScoreResponse.cs
+++ b/Sunrise.API/Serializable/Response/ScoreResponse.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
 using Sunrise.Shared.Database.Models;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Extensions.Beatmaps;
 using Sunrise.Shared.Extensions.Scores;
 using Sunrise.Shared.Utils.Converters;
-using GameMode = osu.Shared.GameMode;
 
 namespace Sunrise.API.Serializable.Response;
 
@@ -24,7 +24,7 @@ public class ScoreResponse
         CountGeki = score.CountGeki;
         CountKatu = score.CountKatu;
         CountMiss = score.CountMiss;
-        GameMode = score.GameMode.ToVanillaGameMode();
+        GameMode = (GameMode)score.GameMode.ToVanillaGameMode();
         Grade = score.Grade;
         Id = score.Id;
         IsPassed = score.IsPassed;

--- a/Sunrise.API/Serializable/Response/UserWithStatsResponse.cs
+++ b/Sunrise.API/Serializable/Response/UserWithStatsResponse.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.API.Serializable.Response;
+
+public class UserWithStatsResponse(UserResponse user, UserStatsResponse? stats = null)
+{
+    [JsonPropertyName("user")]
+    public UserResponse User { get; set; } = user;
+
+    [JsonPropertyName("stats")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public UserStatsResponse? Stats { get; set; } = stats;
+}

--- a/Sunrise.API/Services/AuthService.cs
+++ b/Sunrise.API/Services/AuthService.cs
@@ -65,7 +65,7 @@ public class AuthService(DatabaseService database)
         var newTokenResult = await GenerateJwtToken(userId, TokenExpires);
         if (newTokenResult.IsFailure)
             return Result.Failure<(string, int)>("Error occured while refreshing token.");
-        
+
         var newToken = newTokenResult.Value;
 
         return (newToken, TokenExpires.ToSeconds());
@@ -146,12 +146,6 @@ public class AuthService(DatabaseService database)
     {
         var ip = RegionService.GetUserIpAddress(request);
 
-        var user = new User
-        {
-            Id = ip.GetHashCode(),
-            Username = "Guest"
-        };
-
-        return new BaseSession(user, true);
+        return BaseSession.GenerateGuestSession(ip);
     }
 }

--- a/Sunrise.API/Services/AuthService.cs
+++ b/Sunrise.API/Services/AuthService.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using CSharpFunctionalExtensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using Sunrise.Shared.Application;
@@ -19,41 +20,59 @@ public class AuthService(DatabaseService database)
     private static string TokenSecret => Configuration.WebTokenSecret;
     private static TimeSpan TokenExpires => Configuration.WebTokenExpiration;
 
-    public (string, string, int) GenerateTokens(int userId)
+    public async Task<Result<(string, string, int)>> GenerateTokens(int userId)
     {
-        var token = GenerateJwtToken(userId, TokenExpires);
-        var refreshToken = GenerateJwtToken(userId, TimeSpan.FromDays(30));
+        var tokenResult = await GenerateJwtToken(userId, TokenExpires);
+        if (tokenResult.IsFailure)
+            return Result.Failure<(string, string, int)>(tokenResult.Error);
+
+        var token = tokenResult.Value;
+
+        var refreshTokenResult = await GenerateJwtToken(userId, TimeSpan.FromDays(30));
+        if (refreshTokenResult.IsFailure)
+            return Result.Failure<(string, string, int)>(refreshTokenResult.Error);
+
+        var refreshToken = refreshTokenResult.Value;
 
         return (token, refreshToken, TokenExpires.ToSeconds());
     }
 
     public async Task<User?> GetUserFromToken(string token)
     {
-        ValidateJwtToken(token, out var userId);
-        if (userId == null)
+        var userIdResult = await ValidateJwtToken(token);
+        if (userIdResult.IsFailure)
             return null;
+
+        var userId = userIdResult.Value;
 
         var user = await database.Users.GetValidUser(userId);
 
         return user;
     }
 
-    public (string?, int) RefreshToken(string token)
+    public async Task<Result<(string, int)>> RefreshToken(string token)
     {
-        var newToken = ValidateJwtToken(token, out var userId) ? GenerateJwtToken(userId!.Value, TokenExpires) : null;
+        var userIdResult = await ValidateJwtToken(token);
+        if (!userIdResult.IsSuccess)
+            return Result.Failure<(string, int)>(userIdResult.Error);
 
-        if (userId == null)
-            return (null, 0);
+        var userId = userIdResult.Value;
 
-        var isUserRestricted = database.Users.Moderation.IsUserRestricted(userId.Value).Result;
+        var isUserRestricted = await database.Users.Moderation.IsUserRestricted(userId);
+        if (isUserRestricted)
+            return Result.Failure<(string, int)>("User is restricted.");
 
-        return isUserRestricted ? (null, 0) : (newToken, TokenExpires.ToSeconds());
+        var newTokenResult = await GenerateJwtToken(userId, TokenExpires);
+        if (newTokenResult.IsFailure)
+            return Result.Failure<(string, int)>("Error occured while refreshing token.");
+        
+        var newToken = newTokenResult.Value;
+
+        return (newToken, TokenExpires.ToSeconds());
     }
 
-    private bool ValidateJwtToken(string token, out int? userId)
+    private async Task<Result<int>> ValidateJwtToken(string token)
     {
-        userId = null;
-
         try
         {
             var handler = new JwtSecurityTokenHandler();
@@ -71,17 +90,19 @@ public class AuthService(DatabaseService database)
                 out _);
 
             if (result.Identity is not ClaimsIdentity identity)
-                return false;
+                return Result.Failure<int>("Invalid token");
 
             var userIdClaim = identity.FindFirst(ClaimTypes.NameIdentifier) ?? identity.FindFirst("sub");
             if (userIdClaim == null || !int.TryParse(userIdClaim.Value, out var id))
-                return false;
+                return Result.Failure<int>("Invalid token");
 
-            var user = database.Users.GetUser(id).Result;
+            var user = await database.Users.GetUser(id);
+            if (user == null)
+                return Result.Failure<int>("User not found");
 
             var hashClaim = identity.FindFirst(ClaimTypes.Hash);
             if (hashClaim == null || hashClaim.Value != $"{user.Id}{user.Passhash}".ToHash())
-                return false;
+                return Result.Failure<int>("Invalid user password");
 
             if (user.AccountStatus == UserAccountStatus.Disabled)
             {
@@ -89,21 +110,22 @@ public class AuthService(DatabaseService database)
                 // TODO: Send message from bot about account being enabled
             }
 
-            userId = id;
-            return true;
+            return id;
         }
-        catch
+        catch (Exception ex)
         {
-            return false;
+            return Result.Failure<int>(ex.Message);
         }
     }
 
-    private string GenerateJwtToken(int userId, TimeSpan expires)
+    private async Task<Result<string>> GenerateJwtToken(int userId, TimeSpan expires)
     {
-        var user = database.Users.GetUser(userId).Result;
+        var user = await database.Users.GetUser(userId);
 
         if (user == null)
-            throw new Exception("User not found while generating token");
+        {
+            return Result.Failure<string>("User not found");
+        }
 
         var token = new JwtSecurityToken(
             "Sunrise",
@@ -130,6 +152,6 @@ public class AuthService(DatabaseService database)
             Username = "Guest"
         };
 
-        return new BaseSession(user, isGuest: true);
+        return new BaseSession(user, true);
     }
 }

--- a/Sunrise.API/Services/AuthService.cs
+++ b/Sunrise.API/Services/AuthService.cs
@@ -54,7 +54,7 @@ public class AuthService(DatabaseService database)
     {
         var userIdResult = await ValidateJwtToken(token);
         if (!userIdResult.IsSuccess)
-            return Result.Failure<(string, int)>(userIdResult.Error);
+            return Result.Failure<(string, int)>("Invalid refresh_token");
 
         var userId = userIdResult.Value;
 

--- a/Sunrise.API/Sunrise.API.csproj
+++ b/Sunrise.API/Sunrise.API.csproj
@@ -11,7 +11,13 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Scalar.AspNetCore" Version="2.0.22"/>
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1"/>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.5.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Folder Include="Middlewares\"/>
     </ItemGroup>
 
 </Project>

--- a/Sunrise.API/Sunrise.API.csproj
+++ b/Sunrise.API/Sunrise.API.csproj
@@ -16,8 +16,4 @@
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.5.0"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <Folder Include="Middlewares\"/>
-    </ItemGroup>
-
 </Project>

--- a/Sunrise.Server.Tests/API/AuthController/ApiAuthRefreshTests.cs
+++ b/Sunrise.Server.Tests/API/AuthController/ApiAuthRefreshTests.cs
@@ -109,7 +109,7 @@ public class ApiAuthRefreshTests : ApiTest
         var responseString = await response.Content.ReadAsStringAsync();
         var error = JsonSerializer.Deserialize<ErrorResponse>(responseString);
 
-        Assert.Contains("Invalid refresh_token", error?.Error);
+        Assert.Contains("is restricted", error?.Error);
     }
 
     [Fact]

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
 using Prometheus;
+using Scalar.AspNetCore;
 using Sunrise.API.Controllers;
 using Sunrise.API.Managers;
 using Sunrise.Server.Repositories;
@@ -40,6 +41,14 @@ public static class Bootstrap
             if (Configuration.IncludeUserTokenInLogs) logging.AdditionalRequestHeaders.Add("osu-token");
         });
     }
+
+    public static void AddApiDocs(this WebApplicationBuilder builder)
+    {
+
+        builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen();
+    }
+
 
     public static void AddHangfire(this WebApplicationBuilder builder)
     {
@@ -161,6 +170,18 @@ public static class Bootstrap
         app.Services.GetRequiredService<ChatChannelRepository>();
         app.Services.GetRequiredService<RateLimitRepository>();
         app.Services.GetRequiredService<MatchRepository>();
+    }
+
+    public static void UseScalarApiReference(this WebApplication app)
+    {
+        app.UseSwagger(options => { options.RouteTemplate = "/openapi/{documentName}.json"; });
+
+        app.MapScalarApiReference("docs",
+            options =>
+            {
+                options.Title = "Sunrise API Documentation";
+                options.Theme = ScalarTheme.Mars;
+            });
     }
 
     public static void ApplyDatabaseMigrations(this WebApplication app)

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -12,6 +12,7 @@ using Sunrise.Server.Repositories;
 using Sunrise.Server.Services;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database;
+using Sunrise.Shared.Helpers;
 using Sunrise.Shared.Repositories;
 using Sunrise.Shared.Repositories.Multiplayer;
 using Sunrise.Shared.Services;
@@ -136,6 +137,7 @@ public static class Bootstrap
         builder.Services.AddScoped<Services.AssetService>();
         builder.Services.AddScoped<Services.AuthService>();
         builder.Services.AddScoped<BanchoService>();
+        builder.Services.AddScoped<HttpClientService>();
 
         builder.Services.AddScoped<ScoreService>();
         builder.Services.AddScoped<UserService>();
@@ -145,7 +147,6 @@ public static class Bootstrap
 
         builder.Services.AddScoped<UserAuthService>();
         builder.Services.AddScoped<RegionService>();
-
 
         builder.Services.AddTransient<CalculatorService>();
         builder.Services.AddTransient<BeatmapService>();

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -15,6 +15,9 @@ using Sunrise.Shared.Database;
 using Sunrise.Shared.Repositories;
 using Sunrise.Shared.Repositories.Multiplayer;
 using Sunrise.Shared.Services;
+using AssetService = Sunrise.API.Services.AssetService;
+using AuthService = Sunrise.API.Services.AuthService;
+using WebSocketManager = Sunrise.API.Managers.WebSocketManager;
 
 namespace Sunrise.Server;
 
@@ -108,7 +111,7 @@ public static class Bootstrap
         builder.Services.AddSingleton<RateLimitRepository>();
         builder.Services.AddSingleton<MatchRepository>();
     }
-    
+
     public static void AddApiEndpoints(this WebApplicationBuilder builder)
     {
         builder.Services.AddControllers()
@@ -117,9 +120,11 @@ public static class Bootstrap
             .AddApplicationPart(typeof(BeatmapController).Assembly)
             .AddApplicationPart(typeof(ScoreController).Assembly)
             .AddApplicationPart(typeof(UserController).Assembly);
-        
-        builder.Services.AddScoped<API.Services.AuthService>();
-        builder.Services.AddScoped<API.Services.AssetService>();
+
+        builder.Services.AddSingleton<WebSocketManager>();
+
+        builder.Services.AddScoped<AuthService>();
+        builder.Services.AddScoped<AssetService>();
     }
 
     public static void AddServices(this WebApplicationBuilder builder)
@@ -128,19 +133,19 @@ public static class Bootstrap
         builder.Services.AddScoped<DatabaseService>();
         builder.Services.AddScoped<DirectService>();
         builder.Services.AddScoped<MedalService>();
-        builder.Services.AddScoped<AssetService>();
-        builder.Services.AddScoped<AuthService>();
+        builder.Services.AddScoped<Services.AssetService>();
+        builder.Services.AddScoped<Services.AuthService>();
         builder.Services.AddScoped<BanchoService>();
-        
+
         builder.Services.AddScoped<ScoreService>();
         builder.Services.AddScoped<UserService>();
 
-        builder.Services.AddScoped<AuthService>();
+        builder.Services.AddScoped<Services.AuthService>();
         builder.Services.AddScoped<SessionManager>();
 
         builder.Services.AddScoped<UserAuthService>();
         builder.Services.AddScoped<RegionService>();
-      
+
 
         builder.Services.AddTransient<CalculatorService>();
         builder.Services.AddTransient<BeatmapService>();
@@ -165,7 +170,7 @@ public static class Bootstrap
         database.CheckAndApplyOldTypeOfMigrations();
         database.DbContext.Database.Migrate();
     }
-    
+
     public static void UseStaticBackgrounds(this WebApplication app)
     {
         app.UseStaticFiles(new StaticFileOptions

--- a/Sunrise.Server/Controllers/AssetsController.cs
+++ b/Sunrise.Server/Controllers/AssetsController.cs
@@ -10,13 +10,13 @@ namespace Sunrise.Server.Controllers;
 
 [Subdomain("a", "assets")]
 [ResponseCache(Duration = 300)]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class AssetsController(BanchoService banchoService, AssetService assetService, DatabaseService database) : ControllerBase
 {
     [HttpGet(RequestType.GetAvatar)]
     [HttpGet(RequestType.GetBanchoAvatar)]
     public async Task<IActionResult> GetAvatar(int id, [FromQuery(Name = "default")] bool? fallToDefault)
     {
-
         var getAvatarResult = await assetService.GetAvatar(id, fallToDefault ?? true);
 
         if (getAvatarResult.IsFailure)

--- a/Sunrise.Server/Controllers/BanchoController.cs
+++ b/Sunrise.Server/Controllers/BanchoController.cs
@@ -8,6 +8,7 @@ using Sunrise.Shared.Repositories;
 namespace Sunrise.Server.Controllers;
 
 [Subdomain("c", "c4", "cho")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class BanchoController(ILogger<BanchoController> logger, AuthService authService, BanchoService banchoService, AssetService assetService) : ControllerBase
 {
 
@@ -18,7 +19,7 @@ public class BanchoController(ILogger<BanchoController> logger, AuthService auth
             return await authService.Login(Request, Response);
 
         var sessions = ServicesProviderHolder.GetRequiredService<SessionRepository>();
-        if (!sessions.TryGetSession(out var session, token: token) || session == null)
+        if (!sessions.TryGetSession(out var session, token) || session == null)
             return authService.Relogin();
 
         await using var buffer = new MemoryStream();

--- a/Sunrise.Server/Controllers/DirectController.cs
+++ b/Sunrise.Server/Controllers/DirectController.cs
@@ -8,6 +8,7 @@ namespace Sunrise.Server.Controllers;
 
 [Route("/web")]
 [Subdomain("osu")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class DirectController(DirectService directService, SessionRepository sessions) : ControllerBase
 {
     [HttpGet(RequestType.OsuSearch)]
@@ -57,6 +58,7 @@ public class DirectController(DirectService directService, SessionRepository ses
 
 [ApiController]
 [Subdomain("b")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class BeatmapAssetsController : ControllerBase
 {
     [HttpGet("{type}/{path}")]

--- a/Sunrise.Server/Controllers/ScoreController.cs
+++ b/Sunrise.Server/Controllers/ScoreController.cs
@@ -13,6 +13,7 @@ namespace Sunrise.Server.Controllers;
 
 [Route("/web")]
 [Subdomain("osu")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class ScoreController(ScoreService scoreService, AssetService assetService) : ControllerBase
 {
     [HttpPost(RequestType.OsuSubmitScore)]

--- a/Sunrise.Server/Controllers/WebController.cs
+++ b/Sunrise.Server/Controllers/WebController.cs
@@ -12,6 +12,7 @@ namespace Sunrise.Server.Controllers;
 
 [Route("/web")]
 [Subdomain("osu")]
+[ApiExplorerSettings(IgnoreApi = true)]
 public class WebController(DatabaseService database, SessionRepository sessions, BeatmapService beatmapService, AuthService authService, UserService userService, AssetService assetService) : ControllerBase
 {
     [HttpPost(RequestType.OsuScreenshot)]

--- a/Sunrise.Server/Middleware.cs
+++ b/Sunrise.Server/Middleware.cs
@@ -18,7 +18,15 @@ public sealed class Middleware(
 
         var path = context.Request.Path;
 
-        if (Configuration.BannedIps.Contains(ip.ToString()) && !context.Request.Host.Host.StartsWith("api."))
+        var isApiRequest = context.Request.Host.Host.StartsWith("api.");
+
+        if (Configuration.BannedIps.Contains(ip.ToString()) && !isApiRequest)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
+        if (path.StartsWithSegments(Configuration.ApiDocumentationPath) && !isApiRequest)
         {
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             return;
@@ -57,7 +65,6 @@ public sealed class Middleware(
 
         await next(context);
     }
-
 
     private TokenBucketRateLimiter GetRateLimiter(IPAddress key)
     {

--- a/Sunrise.Server/Program.cs
+++ b/Sunrise.Server/Program.cs
@@ -1,4 +1,5 @@
 using Hangfire;
+using Scalar.AspNetCore;
 using Sunrise.Server;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database;
@@ -13,6 +14,7 @@ builder.AddSingletons();
 
 builder.AddMiddlewares();
 builder.AddApiEndpoints();
+builder.AddApiDocs();
 
 builder.AddSunriseDbContextPool();
 
@@ -29,6 +31,7 @@ app.UseHangfireDashboard("/hangfire",
 
 app.Setup();
 app.UseHealthChecks("/health");
+app.UseScalarApiReference();
 
 app.ApplyDatabaseMigrations();
 app.UseStaticBackgrounds();

--- a/Sunrise.Server/Program.cs
+++ b/Sunrise.Server/Program.cs
@@ -33,6 +33,7 @@ app.UseHealthChecks("/health");
 app.ApplyDatabaseMigrations();
 app.UseStaticBackgrounds();
 app.UseMiddlewares();
+app.UseWebSockets();
 app.Configure();
 
 app.WarmUpSingletons();

--- a/Sunrise.Shared/Application/Configuration.cs
+++ b/Sunrise.Shared/Application/Configuration.cs
@@ -33,6 +33,9 @@ public static class Configuration
     public static int ApiWindow =>
         Config.GetSection("API").GetSection("RateLimit").GetValue<int?>("Window") ?? 10;
 
+    public static string ApiDocumentationPath =>
+        Config.GetSection("API").GetValue<string?>("DocumentationPath") ?? "/docs";
+
     // Files section
     private static string _dataPath => Config.GetSection("Files").GetValue<string?>("DataPath") ?? "";
     public static string DataPath => _dataPath.StartsWith('.') ? Path.Combine(Directory.GetCurrentDirectory(), _dataPath) : _dataPath;

--- a/Sunrise.Shared/Application/Configuration.cs
+++ b/Sunrise.Shared/Application/Configuration.cs
@@ -101,7 +101,10 @@ public static class Configuration
     private static string ObservatoryUrl =>
         Config.GetSection("General").GetValue<string?>("ObservatoryUrl") ?? "";
 
-    public static List<ExternalApi> ExternalApis { get; } = [];
+    public static List<ExternalApi> ExternalApis { get; } =
+    [
+        new(ApiType.GetIPLocation, ApiServer.IpApi, "http://ip-api.com/json/{0}", 0, 1)
+    ];
 
     public static IConfigurationRoot GetConfig()
     {

--- a/Sunrise.Shared/Enums/ApiServer.cs
+++ b/Sunrise.Shared/Enums/ApiServer.cs
@@ -7,5 +7,6 @@ public enum ApiServer
     CatboyBest = 2,
     OsuDirect = 3,
     OldPpy = 5,
-    Observatory = 6
+    Observatory = 6,
+    IpApi = 7
 }

--- a/Sunrise.Shared/Enums/ApiType.cs
+++ b/Sunrise.Shared/Enums/ApiType.cs
@@ -9,5 +9,7 @@ public enum ApiType
     BeatmapSetSearch = 3,
     BeatmapsByBeatmapIds = 4,
 
-    BeatmapDownload = 5
+    BeatmapDownload = 5,
+
+    GetIPLocation = 6
 }

--- a/Sunrise.Shared/Objects/Sessions/BaseSession.cs
+++ b/Sunrise.Shared/Objects/Sessions/BaseSession.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database.Models.Users;
 using Sunrise.Shared.Repositories;
@@ -19,5 +20,16 @@ public class BaseSession(User user, bool isGuest = false)
     {
         var rateLimits = ServicesProviderHolder.GetRequiredService<RateLimitRepository>();
         return rateLimits.GetRemainingCalls(this);
+    }
+
+    public static BaseSession GenerateGuestSession(IPAddress ip)
+    {
+        var user = new User
+        {
+            Id = ip.GetHashCode(),
+            Username = "Guest"
+        };
+
+        return new BaseSession(user, true);
     }
 }

--- a/Sunrise.Shared/Services/BeatmapService.cs
+++ b/Sunrise.Shared/Services/BeatmapService.cs
@@ -8,7 +8,7 @@ using Sunrise.Shared.Objects.Sessions;
 
 namespace Sunrise.Shared.Services;
 
-public class BeatmapService(DatabaseService database)
+public class BeatmapService(DatabaseService database, HttpClientService client)
 {
     public async Task<BeatmapSet?> GetBeatmapSet(BaseSession session, int? beatmapSetId = null,
         string? beatmapHash = null, int? beatmapId = null)
@@ -20,13 +20,13 @@ public class BeatmapService(DatabaseService database)
 
         if (beatmapId != null)
             beatmapSet =
-                await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByBeatmapId, [beatmapId]);
+                await client.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByBeatmapId, [beatmapId]);
         if (beatmapHash != null && beatmapSet == null)
             beatmapSet =
-                await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByHash, [beatmapHash]);
+                await client.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataByHash, [beatmapHash]);
         if (beatmapSetId != null && beatmapSet == null)
             beatmapSet =
-                await RequestsHelper.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataById, [beatmapSetId]);
+                await client.SendRequest<BeatmapSet>(session, ApiType.BeatmapSetDataById, [beatmapSetId]);
 
         if (beatmapSet == null)
             return null;
@@ -44,7 +44,7 @@ public class BeatmapService(DatabaseService database)
 
         if (beatmapFile != null) return beatmapFile;
 
-        beatmapFile = await RequestsHelper.SendRequest<byte[]>(session, ApiType.BeatmapDownload, [beatmapId]);
+        beatmapFile = await client.SendRequest<byte[]>(session, ApiType.BeatmapDownload, [beatmapId]);
 
         if (beatmapFile == null) return null;
 
@@ -55,9 +55,9 @@ public class BeatmapService(DatabaseService database)
     public async Task<List<BeatmapSet>?> SearchBeatmapSets(Session session, string? rankedStatus, string mode,
         string query, Pagination pagination)
     {
-        var beatmapSets = await RequestsHelper.SendRequest<List<BeatmapSet>?>(session,
+        var beatmapSets = await client.SendRequest<List<BeatmapSet>?>(session,
             ApiType.BeatmapSetSearch,
-            [query, pagination.PageSize, pagination.Page*pagination.PageSize, rankedStatus, mode]);
+            [query, pagination.PageSize, pagination.Page * pagination.PageSize, rankedStatus, mode]);
 
         if (beatmapSets == null) return null;
 

--- a/Sunrise.Shared/Services/HttpClientService.cs
+++ b/Sunrise.Shared/Services/HttpClientService.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Web;
 using Microsoft.Extensions.Logging;
@@ -22,8 +23,8 @@ public class HttpClientService
         _logger = loggerFactory.CreateLogger<HttpClientService>();
         _redis = redis;
 
-        _client.DefaultRequestHeaders.Add("Accept", "application/json");
-        _client.DefaultRequestHeaders.Add("User-Agent", "Sunrise");
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _client.DefaultRequestHeaders.UserAgent.ParseAdd("Sunrise");
     }
 
     public async Task<T?> SendRequest<T>(BaseSession session, ApiType type, object?[] args, Dictionary<string, string>? headers = null)

--- a/Sunrise.Shared/Services/HttpClientService.cs
+++ b/Sunrise.Shared/Services/HttpClientService.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Text.Json;
 using System.Web;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Enums;
@@ -9,35 +8,39 @@ using Sunrise.Shared.Objects.Keys;
 using Sunrise.Shared.Objects.Sessions;
 using Sunrise.Shared.Repositories;
 
-namespace Sunrise.Shared.Helpers;
+namespace Sunrise.Shared.Services;
 
-public class RequestsHelper
+public class HttpClientService
 {
-    private static readonly ILogger<RequestsHelper> Logger;
-    private static readonly HttpClient Client = new();
+    private readonly HttpClient _client = new();
+    private readonly ILogger<HttpClientService> _logger;
+    private readonly RedisRepository _redis;
 
-    static RequestsHelper()
+    public HttpClientService(RedisRepository redis)
     {
         var loggerFactory = LoggerFactory.Create(builder => { builder.AddConsole(); });
-        Logger = loggerFactory.CreateLogger<RequestsHelper>();
+        _logger = loggerFactory.CreateLogger<HttpClientService>();
+        _redis = redis;
 
-        Client.DefaultRequestHeaders.Add("Accept", "application/json");
-        Client.DefaultRequestHeaders.Add("User-Agent", "Sunrise");
+        _client.DefaultRequestHeaders.Add("Accept", "application/json");
+        _client.DefaultRequestHeaders.Add("User-Agent", "Sunrise");
     }
 
-    public static async Task<T?> SendRequest<T>(BaseSession session, ApiType type, object?[] args)
+    public async Task<T?> SendRequest<T>(BaseSession session, ApiType type, object?[] args, Dictionary<string, string>? headers = null)
     {
         if (session.IsRateLimited())
         {
-            Logger.LogWarning($"User {session.UserId} got rate limited. Ignoring request.");
+            _logger.LogWarning($"User {session.UserId} got rate limited. Ignoring request.");
             return default;
         }
+
+        headers ??= new Dictionary<string, string>();
 
         var apis = Configuration.ExternalApis.Where(x => x.Type == type).OrderBy(x => x.Priority).ToList();
 
         if (apis is { Count: 0 } or null)
         {
-            Logger.LogWarning($"No API servers found for {type}.");
+            _logger.LogWarning($"No API servers found for {type}.");
             return default;
         }
 
@@ -45,7 +48,7 @@ public class RequestsHelper
         {
             if (args.Length < api.NumberOfRequiredArgs)
             {
-                Logger.LogWarning(
+                _logger.LogWarning(
                     $"Not enough arguments for {type} for {api}. Required {api.NumberOfRequiredArgs}, got {args.Length}.");
                 continue;
             }
@@ -55,35 +58,41 @@ public class RequestsHelper
 
             SunriseMetrics.ExternalApiRequestsCounterInc(type, api.Server, session);
 
-            var (response, isServerRateLimited) = await SendApiRequest<T>(api.Server, requestUri);
+            if (api.Server == ApiServer.Observatory)
+            {
+                if (!string.IsNullOrEmpty(Configuration.ObservatoryApiKey))
+                    headers.Add("Authorization", $"{Configuration.ObservatoryApiKey}");
+            }
+
+            var (response, isServerRateLimited) = await SendApiRequest<T>(api.Server, requestUri, headers);
 
             if (isServerRateLimited) continue;
 
             if (response is not null) return response;
         }
 
-        Logger.LogWarning(
+        _logger.LogWarning(
             $"Failed to get response from any API server for {type} with args {string.Join(", ", args)}.");
 
         return default;
     }
 
     [Obsolete("Use only only if we can't get user session.")]
-    public static async Task<T?> SendRequest<T>(string requestUri, int requestTry = 0)
+    public async Task<T?> SendRequest<T>(string requestUri, int requestTry = 0)
     {
-        var response = await Client.GetAsync(requestUri);
+        var response = await _client.GetAsync(requestUri);
 
         // TODO: Can be refactored to has multiple urls to try and also cache the response.
 
         if (response.StatusCode.Equals(HttpStatusCode.TooManyRequests))
         {
-            Logger.LogWarning($"Request to {requestUri} failed with status code {response.StatusCode}");
+            _logger.LogWarning($"Request to {requestUri} failed with status code {response.StatusCode}");
 
             if (requestTry >= 3)
                 return default;
 
             await Task.Delay(2000);
-            Logger.LogInformation($"Retrying request to {requestUri} (try {requestTry + 1})");
+            _logger.LogInformation($"Retrying request to {requestUri} (try {requestTry + 1})");
             return await SendRequest<T>(requestUri, requestTry + 1);
         }
 
@@ -96,67 +105,50 @@ public class RequestsHelper
         return JsonSerializer.Deserialize<T>(content);
     }
 
-    private static async Task<(T?, bool)> SendApiRequest<T>(ApiServer server, string requestUri)
+    private async Task<(T?, bool)> SendApiRequest<T>(ApiServer server, string requestUri, Dictionary<string, string>? headers = null)
     {
-        using var scope = ServicesProviderHolder.CreateScope();
-        var redis = scope.ServiceProvider.GetRequiredService<RedisRepository>();
-        var isServerRateLimited = await redis.Get<bool?>(RedisKey.ApiServerRateLimited(server));
+        var isServerRateLimited = await _redis.Get<bool?>(RedisKey.ApiServerRateLimited(server));
 
         if (isServerRateLimited is true)
         {
-            Logger.LogWarning($"Server {server} is rate limited. Ignoring request.");
+            _logger.LogWarning($"Server {server} is rate limited. Ignoring request.");
             return (default, true);
         }
 
         try
         {
-            HttpResponseMessage response;
+            using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
 
-            if (server == ApiServer.Observatory)
+            if (headers != null)
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-
-                if (!string.IsNullOrEmpty(Configuration.ObservatoryApiKey))
-                    request.Headers.Add("Authorization", $"{Configuration.ObservatoryApiKey}");
-
-                response = await Client.SendAsync(request);
+                foreach (var header in headers)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
             }
-            else
-            {
-                response = await Client.GetAsync(requestUri);
-            }
+
+            var response = await _client.SendAsync(request);
 
             var rateLimit = string.Empty;
             var rateLimitReset = "60";
-            IEnumerable<string>? rateLimitHeader;
 
             switch (server)
             {
-                case ApiServer.Ppy:
-                case ApiServer.CatboyBest:
-                    rateLimit = response.Headers.TryGetValues("X-RateLimit-Remaining", out rateLimitHeader)
-                        ? rateLimitHeader.FirstOrDefault()
-                        : "60";
-                    break;
-                case ApiServer.OsuDirect:
-                    rateLimit = response.Headers.TryGetValues("RateLimit-Remaining", out rateLimitHeader)
+                case ApiServer.Observatory:
+                    rateLimit = response.Headers.TryGetValues("RateLimit-Remaining", out var rateLimitHeader)
                         ? rateLimitHeader.FirstOrDefault()
                         : "60";
                     rateLimitReset = response.Headers.TryGetValues("RateLimit-Reset", out rateLimitHeader)
                         ? rateLimitHeader.FirstOrDefault()
                         : "60";
                     break;
-                case ApiServer.OldPpy:
-                case ApiServer.Nerinyan:
-                case ApiServer.Observatory:
-                    break;
                 default:
-                    Logger.LogWarning($"Server {server} rate limit headers wasn't set. Ignoring rate limit.");
+                    _logger.LogWarning($"Server {server} rate limit headers wasn't set. Ignoring rate limit.");
                     break;
             }
 
             if (rateLimit is not null && int.TryParse(rateLimit, out var rateLimitInt) && rateLimitInt <= 5)
-                await redis.Set(RedisKey.ApiServerRateLimited(server),
+                await _redis.Set(RedisKey.ApiServerRateLimited(server),
                     true,
                     TimeSpan.FromSeconds(int.TryParse(rateLimitReset, out var rateLimitResetInt)
                         ? rateLimitResetInt
@@ -164,10 +156,10 @@ public class RequestsHelper
 
             if (response.StatusCode.Equals(HttpStatusCode.TooManyRequests))
             {
-                Logger.LogWarning(
+                _logger.LogWarning(
                     $"Request to {server} failed with status code {response.StatusCode}. Rate limiting server for 1 minute.");
 
-                await redis.Set(RedisKey.ApiServerRateLimited(server), true, TimeSpan.FromMinutes(1));
+                await _redis.Set(RedisKey.ApiServerRateLimited(server), true, TimeSpan.FromMinutes(1));
 
                 return (default, true);
             }
@@ -177,13 +169,12 @@ public class RequestsHelper
                 if (response.StatusCode < HttpStatusCode.BadGateway)
                     return (default, false);
 
-                Logger.LogWarning(
+                _logger.LogWarning(
                     $"{server} returned status code {response.StatusCode}. Ignoring server for 10 minutes.");
-                await redis.Set(RedisKey.ApiServerRateLimited(server), true, TimeSpan.FromMinutes(10));
+                await _redis.Set(RedisKey.ApiServerRateLimited(server), true, TimeSpan.FromMinutes(10));
 
                 return (default, false);
             }
-
 
             switch (typeof(T))
             {
@@ -200,7 +191,7 @@ public class RequestsHelper
                     {
                         if (status.ValueKind == JsonValueKind.Number && status.GetInt32() != 200)
                         {
-                            Logger.LogError($"Failed to process request to {server} with uri {requestUri}. Status: {status}");
+                            _logger.LogError($"Failed to process request to {server} with uri {requestUri}. Status: {status}");
                             return (default, false);
                         }
                     }
@@ -210,12 +201,12 @@ public class RequestsHelper
         }
         catch (Exception e)
         {
-            Logger.LogError(e, $"Failed to process request to {server} with uri {requestUri}");
+            _logger.LogError(e, $"Failed to process request to {server} with uri {requestUri}");
             return (default, false);
         }
     }
 
-    private static string SerializeUrlQuery(string url)
+    private string SerializeUrlQuery(string url)
     {
         var results = HttpUtility.ParseQueryString(url);
         var nonEmpty = new Dictionary<string, string>();

--- a/Sunrise.Shared/Services/RegionService.cs
+++ b/Sunrise.Shared/Services/RegionService.cs
@@ -8,7 +8,7 @@ using Sunrise.Shared.Repositories;
 
 namespace Sunrise.Shared.Services;
 
-public class RegionService(RedisRepository redisRepository)
+public class RegionService(RedisRepository redisRepository, HttpClientService client)
 {
     private const string Api = "http://ip-api.com/json/";
 
@@ -21,7 +21,7 @@ public class RegionService(RedisRepository redisRepository)
             return cachedRegion;
         }
 
-        var location = await RequestsHelper.SendRequest<Location>($"{Api}{ip}") ?? new Location();
+        var location = await client.SendRequest<Location>($"{Api}{ip}") ?? new Location();
         location.Ip = ip.ToString();
 
         await redisRepository.Set(RedisKey.LocationFromIp(location.Ip), location);

--- a/Sunrise.Shared/Services/RegionService.cs
+++ b/Sunrise.Shared/Services/RegionService.cs
@@ -1,17 +1,16 @@
 using System.Net;
 using Microsoft.AspNetCore.Http;
+using Sunrise.Shared.Enums;
 using Sunrise.Shared.Enums.Users;
-using Sunrise.Shared.Helpers;
 using Sunrise.Shared.Objects.Keys;
 using Sunrise.Shared.Objects.Serializable;
+using Sunrise.Shared.Objects.Sessions;
 using Sunrise.Shared.Repositories;
 
 namespace Sunrise.Shared.Services;
 
 public class RegionService(RedisRepository redisRepository, HttpClientService client)
 {
-    private const string Api = "http://ip-api.com/json/";
-
     public async Task<Location> GetRegion(IPAddress ip)
     {
         var cachedRegion = await redisRepository.Get<Location>(RedisKey.LocationFromIp(ip.ToString()));
@@ -21,7 +20,9 @@ public class RegionService(RedisRepository redisRepository, HttpClientService cl
             return cachedRegion;
         }
 
-        var location = await client.SendRequest<Location>($"{Api}{ip}") ?? new Location();
+        var guestSession = BaseSession.GenerateGuestSession(ip);
+        var location = await client.SendRequest<Location>(guestSession, ApiType.GetIPLocation, [ip.ToString()]) ?? new Location();
+
         location.Ip = ip.ToString();
 
         await redisRepository.Set(RedisKey.LocationFromIp(location.Ip), location);

--- a/Sunrise.Tests/Abstracts/ApiTest.cs
+++ b/Sunrise.Tests/Abstracts/ApiTest.cs
@@ -14,7 +14,12 @@ public abstract class ApiTest(bool useRedis = false) : DatabaseTest(useRedis)
         var authService = scope.ServiceProvider.GetRequiredService<AuthService>();
 
         user ??= await CreateTestUser();
-        var token = authService.GenerateTokens(user.Id);
+        var tokenResult = await authService.GenerateTokens(user.Id);
+        
+        if (!tokenResult.IsSuccess)
+            throw new Exception(tokenResult.Error);
+        
+        var token = tokenResult.Value;
 
         return new TokenResponse(token.Item1, token.Item2, token.Item3);
     }


### PR DESCRIPTION
This PR adds new `/ws` API endpoint with purpose to send to all listening clients server events, for now it's only going to announce new scores set on the server, but there may be more events supported in the future.

Also, an additional feature of this PR is to add Scalar API docs and make API types more strict. (and some refactoring, of course)

![New Project (1)](https://github.com/user-attachments/assets/3d358e88-d96f-431f-8435-4eea654c5467)
