### PR TITLE
Fix `score/top` ignores some best scores

### DIFF
--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -63,7 +63,7 @@ public class ScoreRepository
             .FilterValidScores()
             .FilterPassedRankedScores()
             .Where(x => x.GameMode == EF.Constant(mode))
-            .SelectBeatmapsBestScores();
+            .SelectUsersPersonalBestScores();
 
         var queryScore = _dbContext.Scores
             .FromSqlRaw(groupedBestScores.ToQueryString())

--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -59,15 +59,16 @@ public class ScoreRepository
 
     public async Task<List<Score>> GetBestScoresByGameMode(GameMode mode, QueryOptions? options = null)
     {
-        var groupedBestScores = _dbContext.Scores.SelectBeatmapsBestScores();
+        var groupedBestScores = _dbContext.Scores
+            .FilterValidScores()
+            .FilterPassedRankedScores()
+            .Where(x => x.GameMode == EF.Constant(mode))
+            .SelectBeatmapsBestScores();
 
         var queryScore = _dbContext.Scores
             .FromSqlRaw(groupedBestScores.ToQueryString())
             .OrderByDescending(x => x.PerformancePoints)
             .ThenByDescending(x => x.WhenPlayed)
-            .FilterValidScores()
-            .FilterPassedRankedScores()
-            .Where(x => x.GameMode == mode)
             .UseQueryOptions(options);
 
         var queryResult = await queryScore.ToListAsync();


### PR DESCRIPTION
Fix `score/top` wrongly groups scores by beatmap best and doesn't filter by gamemode before grouping

Closes #49 