### PR TITLE
Fix: Wrong bonus value calculation

### DIFF
--- a/Sunrise.Server/Commands/ChatCommands/Development/RecalculateScoresCommand.cs
+++ b/Sunrise.Server/Commands/ChatCommands/Development/RecalculateScoresCommand.cs
@@ -37,6 +37,10 @@ public class RecalculateScoresCommand : IChatCommand
             return Task.CompletedTask;
         }
 
+        // Note: Currently unstable, because if there is not beatmap files in database, it will spam Observatory with calls.
+        ChatCommandRepository.SendMessage(session, "This command is currently disabled. Please try again later.");
+        return Task.CompletedTask;
+
         ChatCommandRepository.SendMessage(session,
             "Recalculation started. Server will enter maintenance mode until it's done.");
 

--- a/Sunrise.Shared/Utils/Calculators/PerformanceCalculator.cs
+++ b/Sunrise.Shared/Utils/Calculators/PerformanceCalculator.cs
@@ -85,7 +85,7 @@ public static class PerformanceCalculator
                 {
                     using var performance = Performance.New();
                     performance.Accuracy((uint)accuracy);
-                    
+
                     var ignoreNotScoredMods = mods & ~Mods.Relax;
                     performance.IMods((uint)ignoreNotScoredMods);
                     var result = performance.Calculate(beatmap.Context);
@@ -120,7 +120,7 @@ public static class PerformanceCalculator
         var weightedAccuracy = top100Scores
             .Select((s, i) => Math.Pow(0.95, i) * s.Accuracy)
             .Sum();
-        var bonusAccuracy = 100 / (20 * (1 - Math.Pow(0.95, userBestScores.Count)));
+        var bonusAccuracy = 100 / (20 * (1 - Math.Pow(0.95, top100Scores.Count)));
 
         return weightedAccuracy * bonusAccuracy / 100;
     }
@@ -142,7 +142,7 @@ public static class PerformanceCalculator
         var weightedPp = top100Scores
             .Select((s, i) => Math.Pow(0.95, i) * s.PerformancePoints)
             .Sum();
-        var bonusPp = bonusNumber * (1 - Math.Pow(0.9994, userBestScores.Count));
+        var bonusPp = bonusNumber * (1 - Math.Pow(0.9994, top100Scores.Count));
 
         return weightedPp + bonusPp;
     }


### PR DESCRIPTION
Should fix bug for occurrences then if user submits new score, we will use count of 101 scores for bonus value while using 100 scores in calculation

Also remove pagination from scores (will break retrieval of user's personal best if they're more than 50 scores above his PB)