### PR TITLE
Minor fixes

### DIFF
--- a/Sunrise.Server.Tests/API/AuthController/ApiAuthRegisterTests.cs
+++ b/Sunrise.Server.Tests/API/AuthController/ApiAuthRegisterTests.cs
@@ -207,6 +207,38 @@ public class ApiAuthRegisterTests : ApiTest
     }
 
     [Fact]
+    public async Task TestRegisterUserUsedUsernameWithDifferentCase()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var randomUser = _mocker.User.GetRandomUser();
+        randomUser.Username = randomUser.Username.ToLower();
+        var user = await CreateTestUser(randomUser);
+
+        var password = _mocker.User.GetRandomPassword();
+        var username = user.Username.ToUpper();
+        var email = _mocker.User.GetRandomEmail();
+
+        // Act
+        var response = await client.PostAsJsonAsync("auth/register",
+            new RegisterRequest
+            {
+                Username = username,
+                Password = password,
+                Email = email
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var error = JsonSerializer.Deserialize<ErrorResponse>(responseString);
+
+        Assert.Contains("username already exists", error?.Error);
+    }
+
+    [Fact]
     public async Task TestRegisterUserUsedEmail()
     {
         // Arrange
@@ -217,6 +249,38 @@ public class ApiAuthRegisterTests : ApiTest
         var password = _mocker.User.GetRandomPassword();
         var username = _mocker.User.GetRandomUsername();
         var email = user.Email;
+
+        // Act
+        var response = await client.PostAsJsonAsync("auth/register",
+            new RegisterRequest
+            {
+                Username = username,
+                Password = password,
+                Email = email
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var error = JsonSerializer.Deserialize<ErrorResponse>(responseString);
+
+        Assert.Contains("email already exists", error?.Error);
+    }
+    
+    [Fact]
+    public async Task TestRegisterUserUsedEmailWithDifferentCase()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var randomUser = _mocker.User.GetRandomUser();
+        randomUser.Email = randomUser.Email.ToLower();
+        var user = await CreateTestUser(randomUser);
+
+        var password = _mocker.User.GetRandomPassword();
+        var username = _mocker.User.GetRandomUsername();
+        var email = user.Email.ToUpper();
 
         // Act
         var response = await client.PostAsJsonAsync("auth/register",

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -112,7 +112,7 @@ public static class Bootstrap
                 optionsBuilder.AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>());
 
             optionsBuilder
-                .UseSqlite($"Data Source={Path.Combine(Configuration.DataPath, Configuration.DatabaseName)}");
+                .UseSqlite($"Data Source={Path.Combine(Configuration.DataPath, Configuration.DatabaseName)};Pooling=True;");
 
             optionsBuilder.UseSeeding((ctx, _) => { DatabaseSeeder.UseAsyncSeeding(ctx).Wait(); });
         });

--- a/Sunrise.Server/Controllers/ScoreController.cs
+++ b/Sunrise.Server/Controllers/ScoreController.cs
@@ -31,9 +31,6 @@ public class ScoreController(ScoreService scoreService, AssetService assetServic
         [FromForm(Name = "sbk")] string? storyboardHash = null
     )
     {
-        if (isScoreNotComplete == "1")
-            return Ok("error: no");
-
         var scoreSerialized = ServerParsers.ParseRijndaelString(osuVersion, iv, scoreEncoded);
         var clientHash = ServerParsers.ParseRijndaelString(osuVersion, iv, clientHashEncoded);
         var username = scoreSerialized.Split(':')[1].Trim();

--- a/Sunrise.Server/Services/Helpers/Scores/SubmitScoreHelper.cs
+++ b/Sunrise.Server/Services/Helpers/Scores/SubmitScoreHelper.cs
@@ -41,6 +41,12 @@ public static class SubmitScoreHelper
             return;
         }
 
+        if (!score.IsScoreable)
+        {
+            score.SubmissionStatus = SubmissionStatus.Submitted;
+            return;
+        }
+
         var scores = new List<Score>
         {
             score

--- a/Sunrise.Shared/Database/Migrations/20250320102033_IgnoreCaseForUsernameAndEmail.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250320102033_IgnoreCaseForUsernameAndEmail.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250320102033_IgnoreCaseForUsernameAndEmail")]
+    partial class IgnoreCaseForUsernameAndEmail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.2");

--- a/Sunrise.Shared/Database/Migrations/20250320102033_IgnoreCaseForUsernameAndEmail.cs
+++ b/Sunrise.Shared/Database/Migrations/20250320102033_IgnoreCaseForUsernameAndEmail.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class IgnoreCaseForUsernameAndEmail : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "user",
+                type: "TEXT COLLATE NOCASE",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "user",
+                type: "TEXT COLLATE NOCASE",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Username",
+                table: "user",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT COLLATE NOCASE");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "user",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT COLLATE NOCASE");
+        }
+    }
+}

--- a/Sunrise.Shared/Database/SunriseDbContext.cs
+++ b/Sunrise.Shared/Database/SunriseDbContext.cs
@@ -46,7 +46,7 @@ public class SunriseDbContext : DbContext
     {
         if (!optionsBuilder.IsConfigured)
         {
-            optionsBuilder.UseSqlite($"Data Source={Path.Combine(Configuration.DataPath, Configuration.DatabaseName)}");
+            optionsBuilder.UseSqlite($"Data Source={Path.Combine(Configuration.DataPath, Configuration.DatabaseName)};Pooling=True;");
         }
     }
 }

--- a/Sunrise.Shared/Database/SunriseDbContext.cs
+++ b/Sunrise.Shared/Database/SunriseDbContext.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database.Models;
 using Sunrise.Shared.Database.Models.Events;
@@ -31,7 +30,18 @@ public class SunriseDbContext : DbContext
     public DbSet<Restriction> Restrictions { get; set; }
 
     public DbSet<Score> Scores { get; set; }
-    
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>()
+            .Property(u => u.Username)
+            .HasColumnType("TEXT COLLATE NOCASE");
+
+        modelBuilder.Entity<User>()
+            .Property(u => u.Email)
+            .HasColumnType("TEXT COLLATE NOCASE");
+    }
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (!optionsBuilder.IsConfigured)


### PR DESCRIPTION
Patch notes
- Set "TEXT COLLATE NOCASE" to ignore casing for Username and Email. f8aaabae30f3030501812737d98646694f33034e
- - Fixes issues when two users could have same username/email, but with different casing.
- - Fixes issues when user couldn't log in with his username, if it has different casing.
- Don't query database for failed or not scoreable scores. 8eefb33618aaa59cd17adb48b0461e8f3007af8c
- - Querying database is redundant due to failed scores being always saved with `SubmissionStatus` of `Failed`, as for not scoreable scores, we are free to not track their `SubmissionStatus`, since we are not going to reward any ranked values or show it in leaderboard, thus defaulting their `SubmissionStatus` to `Submitted` is harmless to us.
- Allow users to submit retries, resolves #54. e6d48298fb7c5f3e1110e9f86bd3311ce9578d5f
- Set Pooling to true in the SQLite connection string, should fix "`database is locked`" for multiple transactions 8566241064271748be38c194d35aa04dffc16b01

![twitter_1902067329904918840](https://github.com/user-attachments/assets/c7320420-6600-446b-8579-be2af816278f)
