### PR TITLE
Enable not standard mod recalculations

### DIFF
--- a/Sunrise.API/Serializable/Response/ScoreResponse.cs
+++ b/Sunrise.API/Serializable/Response/ScoreResponse.cs
@@ -25,6 +25,7 @@ public class ScoreResponse
         CountKatu = score.CountKatu;
         CountMiss = score.CountMiss;
         GameMode = (GameMode)score.GameMode.ToVanillaGameMode();
+        GameModeExtended = score.GameMode;
         Grade = score.Grade;
         Id = score.Id;
         IsPassed = score.IsPassed;
@@ -32,6 +33,7 @@ public class ScoreResponse
         LeaderboardRank = score.GetLeaderboardRank().Result;
         MaxCombo = score.MaxCombo;
         Mods = score.Mods.GetModsString();
+        ModsInt = (int)score.Mods;
         Perfect = score.Perfect;
         PerformancePoints = score.PerformancePoints;
         TotalScore = score.TotalScore;
@@ -68,6 +70,9 @@ public class ScoreResponse
     [JsonPropertyName("game_mode")]
     public GameMode GameMode { get; set; }
 
+    [JsonPropertyName("game_mode_extended")]
+    public GameMode GameModeExtended { get; set; }
+
     [JsonPropertyName("grade")]
     public string Grade { get; set; }
 
@@ -89,6 +94,10 @@ public class ScoreResponse
     [JsonPropertyName("mods")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Mods { get; set; }
+
+    [JsonPropertyName("mods_int")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ModsInt { get; set; }
 
     [JsonPropertyName("is_perfect")]
     public bool Perfect { get; set; }

--- a/Sunrise.Server/Commands/ChatCommands/Development/RecalculateUserStatsCommand.cs
+++ b/Sunrise.Server/Commands/ChatCommands/Development/RecalculateUserStatsCommand.cs
@@ -21,10 +21,10 @@ public class RecalculateUserStatsCommand : IChatCommand
 {
     public Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
-        if (args == null || args.Length < 1)
+        if (args == null || args.Length < 2)
         {
             ChatCommandRepository.SendMessage(session,
-                $"Usage: {Configuration.BotPrefix}recalculateuserstats <modeEnum | all> | Example: {Configuration.BotPrefix}recalculateuserstats 0 for osu std.");
+                $"Usage: {Configuration.BotPrefix}recalculateuserstats <modeEnum | all> <isStartMaintenance> | Example: {Configuration.BotPrefix}recalculateuserstats 0 true for osu std calculation with maintenance mode on.");
             return Task.CompletedTask;
         }
 
@@ -35,11 +35,17 @@ public class RecalculateUserStatsCommand : IChatCommand
             ChatCommandRepository.SendMessage(session, "Invalid mode.");
             return Task.CompletedTask;
         }
+        
+        if (!bool.TryParse(args[1], out var isStartMaintenance))
+        {
+            ChatCommandRepository.SendMessage(session, "Invalid isStartMaintenance value.");
+            return Task.CompletedTask;
+        }
 
         BackgroundTaskService.TryStartNewBackgroundJob<RecalculateUserStatsCommand>(
             () => RecalculateUserStats(session.UserId, CancellationToken.None, mode),
             message => ChatCommandRepository.TrySendMessage(session.UserId, message),
-            true);
+            isStartMaintenance);
 
         return Task.CompletedTask;
     }

--- a/Sunrise.Shared/Services/CalculatorService.cs
+++ b/Sunrise.Shared/Services/CalculatorService.cs
@@ -16,12 +16,6 @@ namespace Sunrise.Shared.Services;
 
 public class CalculatorService(Lazy<DatabaseService> database, HttpClientService client)
 {
-    /// <summary>
-    ///     Temporary value to disable all custom not standard mods calculations,
-    ///     will be removed in the next versions.
-    /// </summary>
-    private readonly bool IS_USING_CUSTOM_PP_CALCULATION = false;
-
     public async Task<Result<PerformanceAttributes, ErrorMessage>> CalculateScorePerformance(BaseSession session, Score score)
     {
         var serializedScore = new CalculateScoreRequest(score)
@@ -34,9 +28,7 @@ public class CalculatorService(Lazy<DatabaseService> database, HttpClientService
         if (performanceResult.IsFailure) return performanceResult;
 
         var performance = performanceResult.Value;
-
-        if (IS_USING_CUSTOM_PP_CALCULATION)
-            performance = performance.ApplyNotStandardModRecalculationsIfNeeded(score);
+        performance = performance.ApplyNotStandardModRecalculationsIfNeeded(score);
 
         return performance;
     }
@@ -53,9 +45,7 @@ public class CalculatorService(Lazy<DatabaseService> database, HttpClientService
         if (performancesResult.IsFailure) return performancesResult.ConvertFailure<PerformanceAttributes>();
 
         var performances = performancesResult.Value;
-
-        if (IS_USING_CUSTOM_PP_CALCULATION)
-            performances = performances.Select(p => p.ApplyNotStandardModRecalculationsIfNeeded(100, mods)).ToList();
+        performances = performances.Select(p => p.ApplyNotStandardModRecalculationsIfNeeded(100, mods)).ToList();
 
         return performances.First();
     }
@@ -83,15 +73,14 @@ public class CalculatorService(Lazy<DatabaseService> database, HttpClientService
 
         var performances = performancesResult.Value;
 
-        if (IS_USING_CUSTOM_PP_CALCULATION)
-            performances = performances
-                .Select((p, index) => new
-                {
-                    Performance = p,
-                    Index = index
-                })
-                .Select(x => x.Performance.ApplyNotStandardModRecalculationsIfNeeded(accuracies[x.Index], mods))
-                .ToList();
+        performances = performances
+            .Select((p, index) => new
+            {
+                Performance = p,
+                Index = index
+            })
+            .Select(x => x.Performance.ApplyNotStandardModRecalculationsIfNeeded(accuracies[x.Index], mods))
+            .ToList();
 
         return (performances[0], performances[1], performances[2], performances[3]);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR is a final act of #53, in which we enable not standard mod (Relax mod, to be precise) recalculations.

Patch notes:
- Remove temp `IS_USING_CUSTOM_PP_CALCULATION` value, which blocked custom pp recalculations. 9d31cdc33ea0a12f028a551311c1e8e80d096652
- Add new argument to start stats/scores recalculations without starting maintenance. 6926a868ca2254efb3646cc8372be11bb32dbb91
- A little out-of-scope, but we will now provide new `GameModeExtended` and `ModsInt` variables in ScoreResponse. e9a9667e3043084c9c014cc0c8aa818ef5b9daea

------

Relax stream maps meta is done for. Thank god. 😮‍💨

https://github.com/user-attachments/assets/9603b70f-8d4b-428f-a865-00f37857ffb7

<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif -->
