### PR TITLE
Update pp custom calculations

### DIFF
--- a/Sunrise.Server.Tests/Extensions/PerformanceAttributesExtensionsTests.cs
+++ b/Sunrise.Server.Tests/Extensions/PerformanceAttributesExtensionsTests.cs
@@ -1,0 +1,82 @@
+﻿using osu.Shared;
+using Sunrise.Shared.Database.Models;
+using Sunrise.Shared.Extensions.Beatmaps;
+using Sunrise.Shared.Extensions.Performances;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using GameMode = Sunrise.Shared.Enums.Beatmaps.GameMode;
+
+namespace Sunrise.Server.Tests.Extensions;
+
+public class PerformanceAttributesExtensionsTests
+{
+
+    public static GameMode[] CustomRecalculatedGameModes = [GameMode.RelaxStandard, GameMode.AutopilotStandard, GameMode.RelaxCatchTheBeat];
+    private readonly MockService _mocker = new();
+
+    public static IEnumerable<object[]> GetGameModes()
+    {
+        return Enum.GetValues(typeof(GameMode)).Cast<GameMode>().Select(mode => new object[]
+        {
+            mode
+        });
+    }
+
+    [Theory]
+    [MemberData(nameof(GetGameModes))]
+    public void IsShouldNotRecalculatePerformancesWhichDoesntSupportRecalculation(GameMode gameMode)
+    {
+        // Arrange
+        var performance = _mocker.Score.GetRandomPerformanceAttributes();
+        performance.Difficulty.Mode = (GameMode)gameMode.ToVanillaGameMode();
+
+        var isSupportsCustomRecalculation = CustomRecalculatedGameModes.Contains(gameMode);
+
+        var mods = gameMode.GetGamemodeMods() | Mods.Easy; // Add Easy to change RelaxCtb value;
+
+        var oldPpValue = performance.PerformancePoints;
+
+        // Act
+        var newPp = performance.ApplyNotStandardModRecalculationsIfNeeded(_mocker.Score.GetRandomAccuracy(), mods);
+        
+        // Assert
+        if (isSupportsCustomRecalculation)
+        {
+            Assert.NotEqual(newPp.PerformancePoints, oldPpValue);
+        }
+        else
+        {
+            Assert.Equal(newPp.PerformancePoints, oldPpValue);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(GetGameModes))]
+    public void IsShouldNotRecalculateScoresWhichDoesntSupportRecalculation(GameMode gameMode)
+    {
+        // Arrange
+        var score = _mocker.Score.GetRandomScore();
+        var performance = _mocker.Score.GetRandomPerformanceAttributes();
+        performance.Difficulty.Mode = (GameMode)gameMode.ToVanillaGameMode();
+
+        score.GameMode = gameMode;
+        score.Mods = gameMode.GetGamemodeMods() | Mods.Easy; // Add Easy to change RelaxCtb value;
+
+        var isSupportsCustomRecalculation = CustomRecalculatedGameModes.Contains(gameMode);
+
+        var oldPpValue = performance.PerformancePoints;
+
+        // Act
+        var newPp = performance.ApplyNotStandardModRecalculationsIfNeeded(score);
+        
+        // Assert
+        if (isSupportsCustomRecalculation)
+        {
+            Assert.NotEqual(newPp.PerformancePoints, oldPpValue);
+        }
+        else
+        {
+            Assert.Equal(newPp.PerformancePoints, oldPpValue);
+        }
+    }
+}

--- a/Sunrise.Server.Tests/Extensions/StringExtensionsTests.cs
+++ b/Sunrise.Server.Tests/Extensions/StringExtensionsTests.cs
@@ -31,6 +31,7 @@ public class StringExtensionsTests
     [MemberData(nameof(GetInvalidCharacters))]
     public void IsValidStringCharacters_WithInvalidString_ReturnsFalse(string invalidCharacter)
     {
+        // Arrange
         var str = $"test123{invalidCharacter}";
 
         // Act

--- a/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
+++ b/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
@@ -20,7 +20,7 @@ public static class PerformanceAttributesExtensions
 
     public static PerformanceAttributes ApplyNotStandardModRecalculationsIfNeeded(this PerformanceAttributes performance, double accuracy, Mods mods)
     {
-        if (mods.HasFlag(Mods.Relax))
+        if (mods.HasFlag(Mods.Relax) && performance.Difficulty.Mode == GameMode.Standard)
         {
             performance.PerformancePoints = RecalculateToRelaxPerformance(performance, accuracy, mods);
         }

--- a/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
+++ b/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using osu.Shared;
 using Sunrise.Shared.Database.Models;
 using Sunrise.Shared.Objects.Serializable.Performances;
+using GameMode = Sunrise.Shared.Enums.Beatmaps.GameMode;
 
 namespace Sunrise.Shared.Extensions.Performances;
 
@@ -8,10 +9,11 @@ public static class PerformanceAttributesExtensions
 {
     public static PerformanceAttributes ApplyNotStandardModRecalculationsIfNeeded(this PerformanceAttributes performance, Score score)
     {
-        if (score.Mods.HasFlag(Mods.Relax))
+        if (score.Mods.HasFlag(Mods.Relax) && score.GameMode == GameMode.RelaxStandard)
         {
             performance.PerformancePoints = RecalculateToRelaxPerformance(performance, score.Accuracy, score.Mods);
         }
+
 
         return performance;
     }

--- a/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
+++ b/Sunrise.Shared/Extensions/Performances/PerformanceAttributesExtensions.cs
@@ -11,9 +11,18 @@ public static class PerformanceAttributesExtensions
     {
         if (score.Mods.HasFlag(Mods.Relax) && score.GameMode == GameMode.RelaxStandard)
         {
-            performance.PerformancePoints = RecalculateToRelaxPerformance(performance, score.Accuracy, score.Mods);
+            performance.PerformancePoints = RecalculateToRelaxStdPerformance(performance, score.Accuracy, score.Mods);
         }
 
+        if (score.Mods.HasFlag(Mods.Relax) && score.GameMode == GameMode.RelaxCatchTheBeat)
+        {
+            performance.PerformancePoints = RecalculateToRelaxCtbPerformance(performance, score.Mods);
+        }
+
+        if (score.Mods.HasFlag(Mods.Relax2) && score.GameMode == GameMode.AutopilotStandard)
+        {
+            performance.PerformancePoints = RecalculateToAutopilotStdPerformance(performance);
+        }
 
         return performance;
     }
@@ -22,15 +31,25 @@ public static class PerformanceAttributesExtensions
     {
         if (mods.HasFlag(Mods.Relax) && performance.Difficulty.Mode == GameMode.Standard)
         {
-            performance.PerformancePoints = RecalculateToRelaxPerformance(performance, accuracy, mods);
+            performance.PerformancePoints = RecalculateToRelaxStdPerformance(performance, accuracy, mods);
+        }
+
+        if (mods.HasFlag(Mods.Relax) && performance.Difficulty.Mode == GameMode.CatchTheBeat)
+        {
+            performance.PerformancePoints = RecalculateToRelaxCtbPerformance(performance, mods);
+        }
+
+        if (mods.HasFlag(Mods.Relax2) && performance.Difficulty.Mode == GameMode.Standard)
+        {
+            performance.PerformancePoints = RecalculateToAutopilotStdPerformance(performance);
         }
 
         return performance;
     }
 
-    private static double RecalculateToRelaxPerformance(PerformanceAttributes performance, double accuracy, Mods mods)
+    private static double RecalculateToRelaxStdPerformance(PerformanceAttributes performance, double accuracy, Mods mods)
     {
-        var multi = CalculatePpMultiplier(performance);
+        var multi = CalculateStdPpMultiplier(performance);
         var streamsNerf = CalculateStreamsNerf(performance);
 
         double accDepression = 1;
@@ -48,18 +67,43 @@ public static class PerformanceAttributesExtensions
 
         if (mods.HasFlag(Mods.HardRock))
         {
-            multi *= Math.Max(1, 1 * (CalculateMissPenalty(performance) / 1.79));
+            multi *= Math.Min(2, Math.Max(1, 1 * (CalculateMissPenalty(performance) / 1.80)));
         }
 
         var relaxPp = Math.Pow(
-            Math.Pow(performance.PerformancePointsAim ?? 0, 1.11) +
-            Math.Pow(performance.PerformancePointsSpeed ?? 0, 0.83 * accDepression) +
-            Math.Pow(performance.PerformancePointsAccuracy ?? 0, 1.04) +
-            Math.Pow(performance.PerformancePointsFlashlight ?? 0, 1.06),
+            Math.Pow(performance.PerformancePointsAim ?? 0, 1.1) +
+            Math.Pow(performance.PerformancePointsSpeed ?? 0, 0.7 * accDepression) +
+            Math.Pow(performance.PerformancePointsAccuracy ?? 0, 1.1) +
+            Math.Pow(performance.PerformancePointsFlashlight ?? 0, 1.13),
             1.0 / 1.1
         ) * multi;
 
         return double.IsNaN(relaxPp) ? 0.0 : relaxPp;
+    }
+
+    private static double RecalculateToAutopilotStdPerformance(PerformanceAttributes performance)
+    {
+        var multi = CalculateStdPpMultiplier(performance);
+
+        var relaxPp = Math.Pow(
+            Math.Pow(performance.PerformancePointsAim ?? 0, 0.6) +
+            Math.Pow(performance.PerformancePointsSpeed ?? 0, 1.3) +
+            Math.Pow(performance.PerformancePointsAccuracy ?? 0, 1.05) +
+            Math.Pow(performance.PerformancePointsFlashlight ?? 0, 1.13),
+            1.0 / 1.1
+        ) * multi;
+
+        return double.IsNaN(relaxPp) ? 0.0 : relaxPp;
+    }
+
+    private static double RecalculateToRelaxCtbPerformance(PerformanceAttributes performance, Mods mods)
+    {
+        if (mods.HasFlag(Mods.Easy))
+        {
+            performance.PerformancePoints *= 0.67;
+        }
+
+        return performance.PerformancePoints;
     }
 
     private static double CalculateMissPenalty(PerformanceAttributes performance)
@@ -87,7 +131,7 @@ public static class PerformanceAttributesExtensions
         return Math.Round(aimValue / speedValue * 100) / 100;
     }
 
-    private static double CalculatePpMultiplier(PerformanceAttributes performance)
+    private static double CalculateStdPpMultiplier(PerformanceAttributes performance)
     {
         var aimValue = performance.PerformancePointsAim ?? 0;
         var speedValue = performance.PerformancePointsSpeed ?? 0;

--- a/Sunrise.Tests/Services/Mock/Services/MockScoreService.cs
+++ b/Sunrise.Tests/Services/Mock/Services/MockScoreService.cs
@@ -1,6 +1,7 @@
 ﻿using osu.Shared;
 using Sunrise.Shared.Database.Models;
 using Sunrise.Shared.Enums.Beatmaps;
+using Sunrise.Shared.Objects.Serializable.Performances;
 using Sunrise.Tests.Extensions;
 using GameMode = Sunrise.Shared.Enums.Beatmaps.GameMode;
 using SubmissionStatus = Sunrise.Shared.Enums.Scores.SubmissionStatus;
@@ -46,6 +47,56 @@ public class MockScoreService(MockService service)
         };
     }
 
+
+    public PerformanceAttributes GetRandomPerformanceAttributes()
+    {
+        return new PerformanceAttributes
+        {
+            PerformancePoints = service.GetRandomInteger(length: 6),
+            Difficulty = new DifficultyAttributes
+            {
+                Aim = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                AimDifficultStrainCount = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                AR = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                Color = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                Flashlight = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                GreatHitWindow = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                HP = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                IsConvert = service.GetRandomBoolean(),
+                MaxCombo = service.GetRandomInteger(),
+                Mode = GetRandomGameMode(),
+                MonoStaminaFactor = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                NCircles = service.GetRandomInteger(length: 6),
+                NDroplets = service.GetRandomInteger(length: 6),
+                NFruits = service.GetRandomInteger(length: 6),
+                NHoldNotes = service.GetRandomInteger(length: 6),
+                NLargeTicks = service.GetRandomInteger(length: 6),
+                NObjects = service.GetRandomInteger(length: 6),
+                NSliders = service.GetRandomInteger(length: 6),
+                NSpinners = service.GetRandomInteger(length: 6),
+                NTinyDroplets = service.GetRandomInteger(length: 6),
+                OD = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                OkHitWindow = service.GetRandomInteger(length: 6),
+                Peak = service.GetRandomInteger(length: 6),
+                Rhythm = service.GetRandomInteger(length: 6),
+                SliderFactor = service.GetRandomInteger(length: 6),
+                Speed = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                SpeedDifficultStrainCount = service.GetRandomInteger(length: 6),
+                SpeedNoteCount = service.GetRandomInteger(length: 6),
+                Stamina = service.GetRandomInteger(minInt: 0, maxInt: 10),
+                Stars = service.GetRandomInteger(minInt: 0, maxInt: 10)
+            },
+            State = new ScoreState(),
+            EffectiveMissCount = service.GetRandomInteger(length: 6),
+            EstimatedUnstableRate = service.GetRandomInteger(length: 6),
+            PerformancePointsAccuracy = service.GetRandomInteger(length: 6),
+            PerformancePointsAim = service.GetRandomInteger(length: 6),
+            PerformancePointsDifficulty = service.GetRandomInteger(length: 6),
+            PerformancePointsFlashlight = service.GetRandomInteger(length: 6),
+            PerformancePointsSpeed = service.GetRandomInteger(length: 6)
+        };
+    }
+
     public Score GetBestScoreableRandomScore()
     {
         var score = GetRandomScore();
@@ -64,6 +115,11 @@ public class MockScoreService(MockService service)
         var random = new Random();
         var values = Enum.GetValues(typeof(GameMode));
         return (GameMode)values.GetValue(random.Next(values.Length))!;
+    }
+
+    public int GetRandomAccuracy()
+    {
+        return service.GetRandomInteger(minInt: 0, maxInt: 100);
     }
 
     public string GetRandomBeatmapGrade()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds custom pp calculations for [StandardAutopilot](https://github.com/SunriseCommunity/Sunrise/commit/a5901bd2b7f0dd7aa45be6adb348bf729f69df71) and [RelaxCatchTheBeat](https://github.com/SunriseCommunity/Sunrise/commit/a5901bd2b7f0dd7aa45be6adb348bf729f69df71). 
We also [update pp values for RelaxStandard](https://github.com/SunriseCommunity/Sunrise/commit/51ae05840d9d43e13f1edf982316cef6906caf04).
It also has fixes for the bug when custom pp calculations were applied to wrong gamemodes, [tests were added to replicate bug environment](https://github.com/SunriseCommunity/Sunrise/commit/f96c529e8694892fcb509ce068f82805976b3137).

<!--- Describe your changes in detail -->



<!--- Don't forget to add some funny or just cool image/gif -->

![image](https://github.com/user-attachments/assets/009fa2dd-00e9-4e5a-8e2c-3faf3d34e0cd)

