### PR TITLE
Add beatmapsets search endpoint

### DIFF
--- a/Sunrise.API/Controllers/BeatmapController.cs
+++ b/Sunrise.API/Controllers/BeatmapController.cs
@@ -192,7 +192,7 @@ public class BeatmapController(SessionManager sessionManager, DatabaseService da
     [ProducesResponseType(typeof(BeatmapResponse[]), StatusCodes.Status200OK)]
     public async Task<IActionResult> SearchBeatmapsets(
         [FromQuery(Name = "query")] string query,
-        [FromQuery(Name = "status")] BeatmapStatusSearch? status,
+        [FromQuery(Name = "status")] BeatmapStatusSearch[]? status,
         [FromQuery(Name = "mode")] GameMode? mode,
         [FromQuery(Name = "limit")] int limit = 50,
         [FromQuery(Name = "page")] int page = 1
@@ -209,7 +209,7 @@ public class BeatmapController(SessionManager sessionManager, DatabaseService da
 
         var session = await sessionManager.GetSessionFromRequest(Request) ?? AuthService.GenerateIpSession(Request);
 
-        var beatmapsetStatus = ((int)(status ?? BeatmapStatusSearch.Any)).ToString();
+        var beatmapsetStatus = status?.Any() == true ? string.Join("&status=", status.Select(s => (int)s)) : null;
         var beatmapsetGamemode = mode.HasValue ? (int)mode : -1;
 
         var beatmapSets = await beatmapService.SearchBeatmapSets(session,

--- a/Sunrise.API/Controllers/BeatmapController.cs
+++ b/Sunrise.API/Controllers/BeatmapController.cs
@@ -6,6 +6,7 @@ using Sunrise.API.Serializable.Response;
 using Sunrise.Shared.Attributes;
 using Sunrise.Shared.Database;
 using Sunrise.Shared.Database.Objects;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Enums.Leaderboards;
 using Sunrise.Shared.Objects.Serializable.Performances;
 using Sunrise.Shared.Repositories;
@@ -191,6 +192,8 @@ public class BeatmapController(SessionManager sessionManager, DatabaseService da
     [ProducesResponseType(typeof(BeatmapResponse[]), StatusCodes.Status200OK)]
     public async Task<IActionResult> SearchBeatmapsets(
         [FromQuery(Name = "query")] string query,
+        [FromQuery(Name = "status")] BeatmapStatusSearch? status,
+        [FromQuery(Name = "mode")] GameMode? mode,
         [FromQuery(Name = "limit")] int limit = 50,
         [FromQuery(Name = "page")] int page = 1
     )
@@ -206,9 +209,12 @@ public class BeatmapController(SessionManager sessionManager, DatabaseService da
 
         var session = await sessionManager.GetSessionFromRequest(Request) ?? AuthService.GenerateIpSession(Request);
 
+        var beatmapsetStatus = ((int)(status ?? BeatmapStatusSearch.Any)).ToString();
+        var beatmapsetGamemode = mode.HasValue ? (int)mode : -1;
+
         var beatmapSets = await beatmapService.SearchBeatmapSets(session,
-            null,
-            "-1", // Any mode
+            beatmapsetStatus,
+            beatmapsetGamemode.ToString(),
             query,
             new Pagination(page - 1, limit));
 

--- a/Sunrise.API/Controllers/BeatmapController.cs
+++ b/Sunrise.API/Controllers/BeatmapController.cs
@@ -210,7 +210,7 @@ public class BeatmapController(SessionManager sessionManager, DatabaseService da
             null,
             "-1", // Any mode
             query,
-            new Pagination(page, limit));
+            new Pagination(page - 1, limit));
 
         return Ok(new BeatmapSetsResponse(beatmapSets?.Select(s => new BeatmapSetResponse(session, s)).ToList() ?? [], null));
     }

--- a/Sunrise.API/Serializable/Response/BeatmapSetsResponse.cs
+++ b/Sunrise.API/Serializable/Response/BeatmapSetsResponse.cs
@@ -4,7 +4,7 @@ namespace Sunrise.API.Serializable.Response;
 
 public class BeatmapSetsResponse
 {
-    public BeatmapSetsResponse(List<BeatmapSetResponse> sets, int totalCount)
+    public BeatmapSetsResponse(List<BeatmapSetResponse> sets, int? totalCount)
     {
         Sets = sets;
         TotalCount = totalCount;
@@ -19,5 +19,6 @@ public class BeatmapSetsResponse
     public List<BeatmapSetResponse> Sets { get; set; }
 
     [JsonPropertyName("total_count")]
-    public int TotalCount { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? TotalCount { get; set; }
 }

--- a/Sunrise.Server/Extensions/BeatmapSetExtensions.cs
+++ b/Sunrise.Server/Extensions/BeatmapSetExtensions.cs
@@ -1,5 +1,5 @@
-using Sunrise.Server.Enums;
 using Sunrise.Server.Utils;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Objects.Serializable;
 using Sunrise.Shared.Objects.Sessions;
 

--- a/Sunrise.Server/Services/DirectService.cs
+++ b/Sunrise.Server/Services/DirectService.cs
@@ -1,7 +1,7 @@
-using Sunrise.Server.Enums;
 using Sunrise.Server.Extensions;
 using Sunrise.Server.Utils;
 using Sunrise.Shared.Database.Objects;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Objects.Sessions;
 using Sunrise.Shared.Services;
 
@@ -26,7 +26,7 @@ public class DirectService(BeatmapService beatmapService)
         var parsedStatus = BeatmapStatusSearchParser.WebStatusToSearchStatus(ranked);
         var beatmapStatus = parsedStatus == BeatmapStatusSearch.Any ? "" : parsedStatus.ToString("D");
 
-        var beatmapSets = await beatmapService.SearchBeatmapSets(session, beatmapStatus, mode, query, new Pagination(page-1, 100));
+        var beatmapSets = await beatmapService.SearchBeatmapSets(session, beatmapStatus, mode, query, new Pagination(page - 1, 100));
 
         if (beatmapSets == null)
             return "0";

--- a/Sunrise.Server/Utils/BeatmapStatusSearchParser.cs
+++ b/Sunrise.Server/Utils/BeatmapStatusSearchParser.cs
@@ -1,4 +1,4 @@
-﻿using Sunrise.Server.Enums;
+﻿using Sunrise.Shared.Enums.Beatmaps;
 
 namespace Sunrise.Server.Utils;
 

--- a/Sunrise.Shared/Enums/Beatmaps/BeatmapStatusSearch.cs
+++ b/Sunrise.Shared/Enums/Beatmaps/BeatmapStatusSearch.cs
@@ -1,9 +1,10 @@
-﻿namespace Sunrise.Server.Enums;
+﻿namespace Sunrise.Shared.Enums.Beatmaps;
 
 public enum BeatmapStatusSearch
 {
-    Any = -2,
-    Graveyard = -1,
+    Any = -3,
+    Graveyard = -2,
+    Wip = -1,
     Pending = 0,
     Ranked = 1,
     Approved = 2,

--- a/Sunrise.Shared/Objects/Serializable/BeatmapSet.cs
+++ b/Sunrise.Shared/Objects/Serializable/BeatmapSet.cs
@@ -168,7 +168,7 @@ public class BeatmapAvailability
 public class BeatmapSetGenre
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public int? Id { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }
@@ -177,7 +177,7 @@ public class BeatmapSetGenre
 public class BeatmapSetLanguage
 {
     [JsonPropertyName("id")]
-    public int Id { get; set; }
+    public int? Id { get; set; }
 
     [JsonPropertyName("name")]
     public string Name { get; set; }

--- a/Sunrise.Shared/Services/BeatmapService.cs
+++ b/Sunrise.Shared/Services/BeatmapService.cs
@@ -40,7 +40,7 @@ public class BeatmapService(DatabaseService database, HttpClientService client)
         return beatmapSet;
     }
 
-    public async Task<List<BeatmapSet>?> SearchBeatmapSets(Session session, string? rankedStatus, string mode,
+    public async Task<List<BeatmapSet>?> SearchBeatmapSets(BaseSession session, string? rankedStatus, string mode,
         string query, Pagination pagination)
     {
         var beatmapSets = (await client.SendRequest<List<BeatmapSet>?>(session,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds new API endpoint `/beatmapset/search` which uses observatory to search beatmapsets. 

This endpoint will allow to implement beatmapsets search on Sunset.

As a side effect this PR fixes enums in BeatmapStatusSearch: a3f795a3b329ade2fd38a347135766e193b51115

<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif -->

![](https://pbs.twimg.com/media/GpBWWWUWcAEq4Dx?format=jpg&name=4096x4096)
