### PR TITLE
Add Deafult GameMode field for user

### DIFF
--- a/Sunrise.API/Serializable/Request/EditDefaultGameModeRequest.cs
+++ b/Sunrise.API/Serializable/Request/EditDefaultGameModeRequest.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using Sunrise.Shared.Enums.Beatmaps;
+
+namespace Sunrise.API.Serializable.Request;
+
+public class EditDefaultGameModeRequest
+{
+    [JsonPropertyName("default_gamemode")]
+    public required GameMode DefaultGameMode { get; set; }
+}

--- a/Sunrise.API/Serializable/Response/UserResponse.cs
+++ b/Sunrise.API/Serializable/Response/UserResponse.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Sunrise.API.Enums;
 using Sunrise.API.Services;
 using Sunrise.Shared.Database.Models.Users;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Enums.Users;
 using Sunrise.Shared.Extensions.Users;
 using Sunrise.Shared.Repositories;
@@ -32,6 +33,7 @@ public class UserResponse
         LastOnlineTime = session != null ? session.Attributes.LastPingRequest : user.LastOnlineTime;
         IsRestricted = user.IsRestricted();
         SilencedUntil = user.SilencedUntil > DateTime.UtcNow ? user.SilencedUntil : null!;
+        DefaultGameMode = user.DefaultGameMode;
         Badges = UserService.GetUserBadges(user);
     }
 
@@ -69,6 +71,9 @@ public class UserResponse
     [JsonConverter(typeof(DateTimeWithTimezoneConverter))]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public DateTime? SilencedUntil { get; set; }
+
+    [JsonPropertyName("default_gamemode")]
+    public GameMode DefaultGameMode { get; set; }
 
     [JsonPropertyName("badges")]
     public List<UserBadge> Badges { get; set; }

--- a/Sunrise.Server.Tests/API/UserController/ApiUserEditDefaultGameModeTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserEditDefaultGameModeTests.cs
@@ -1,0 +1,148 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Sunrise.API.Serializable.Request;
+using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Beatmaps;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.API.UserController;
+
+public class ApiUserEditDefaultGameModeTests : ApiTest
+{
+    private readonly MockService _mocker = new();
+    
+    public static IEnumerable<object[]> GetGameModes()
+    {
+        return Enum.GetValues(typeof(GameMode)).Cast<GameMode>().Select(mode => new object[]
+        {
+            mode
+        });
+    }
+
+    [Fact]
+    public async Task TestEditDefaultGameModeWithoutAuthToken()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/default-gamemode",
+            new EditDefaultGameModeRequest
+            {
+                DefaultGameMode = _mocker.Score.GetRandomGameMode()
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("authorize to access", responseError?.Error);
+    }
+
+    [Fact]
+    public async Task TestEditDefaultGameModeWithActiveRestriction()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+
+        var result = await Database.Users.Moderation.RestrictPlayer(user.Id, null, "Test");
+        if (result.IsFailure)
+            throw new Exception(result.Error);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/default-gamemode",
+            new EditDefaultGameModeRequest
+            {
+                DefaultGameMode = _mocker.Score.GetRandomGameMode()
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("authorize to access", responseError?.Error);
+    }
+
+    [Fact]
+    public async Task TestEditDefaultGameModeWithoutBody()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/default-gamemode", new StringContent(""));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("invalid", responseError?.Error);
+    }
+
+    [Fact]
+    public async Task TestEditDefaultGameModeWithInvalidBody()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+
+        var newGameMode = _mocker.GetRandomString();
+
+
+        var json = $"{{\"default_gamemode\":\"{newGameMode}\"}}";
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("user/edit/default-gamemode", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("invalid", responseError?.Error);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetGameModes))]
+    public async Task TestEditDefaultGameMode(GameMode mode)
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+
+        var newDescription = _mocker.GetRandomString();
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/default-gamemode",
+            new EditDefaultGameModeRequest
+            {
+                DefaultGameMode = mode
+            });
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var updatedUser = await Database.Users.GetUser(user.Id);
+        Assert.NotNull(updatedUser);
+
+        Assert.Equal(mode, updatedUser.DefaultGameMode);
+    }
+}

--- a/Sunrise.Shared/Database/Migrations/20250506223339_AddDefaultGamemodeToUser.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250506223339_AddDefaultGamemodeToUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250506223339_AddDefaultGamemodeToUser")]
+    partial class AddDefaultGamemodeToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sunrise.Shared/Database/Migrations/20250506223339_AddDefaultGamemodeToUser.cs
+++ b/Sunrise.Shared/Database/Migrations/20250506223339_AddDefaultGamemodeToUser.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDefaultGamemodeToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BestGlobalRankDate",
+                table: "user_stats",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "BestGlobalRank",
+                table: "user_stats",
+                type: "BIGINT",
+                nullable: false,
+                defaultValue: 0L,
+                oldClrType: typeof(long),
+                oldType: "BIGINT",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BestCountryRankDate",
+                table: "user_stats",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "BestCountryRank",
+                table: "user_stats",
+                type: "BIGINT",
+                nullable: false,
+                defaultValue: 0L,
+                oldClrType: typeof(long),
+                oldType: "BIGINT",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "DefaultGameMode",
+                table: "user",
+                type: "tinyint unsigned",
+                nullable: false,
+                defaultValue: (byte)0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultGameMode",
+                table: "user");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BestGlobalRankDate",
+                table: "user_stats",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "BestGlobalRank",
+                table: "user_stats",
+                type: "BIGINT",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "BIGINT");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BestCountryRankDate",
+                table: "user_stats",
+                type: "datetime(6)",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime(6)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "BestCountryRank",
+                table: "user_stats",
+                type: "BIGINT",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "BIGINT");
+        }
+    }
+}

--- a/Sunrise.Shared/Database/Models/Users/User.cs
+++ b/Sunrise.Shared/Database/Models/Users/User.cs
@@ -1,9 +1,10 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
-using osu.Shared;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Enums;
+using Sunrise.Shared.Enums.Beatmaps;
 using Sunrise.Shared.Enums.Users;
+using PlayerRank = osu.Shared.PlayerRank;
 
 namespace Sunrise.Shared.Database.Models.Users;
 
@@ -27,6 +28,7 @@ public class User
     public string Friends { get; set; } = string.Empty;
     public UserAccountStatus AccountStatus { get; set; } = UserAccountStatus.Active;
     public DateTime SilencedUntil { get; set; } = DateTime.MinValue;
+    public GameMode DefaultGameMode { get; set; } = GameMode.Standard;
 
     public ICollection<UserFile> UserFiles { get; set; } = new List<UserFile>();
 


### PR DESCRIPTION
This PR adds functionality for the frontend to load user's default game mode (currently default to osu!std) as default. 

Also, user can update their default game mode via POST `edit/default-gamemode` endpoint

Test cases were added to for the new endpoint

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif -->
