### PR TITLE
Add user metadata and user relationships

### DIFF
--- a/Sunrise.API/Serializable/Request/EditUserMetadataRequest.cs
+++ b/Sunrise.API/Serializable/Request/EditUserMetadataRequest.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Sunrise.Shared.Enums.Users;
+
+namespace Sunrise.API.Serializable.Request;
+
+public class EditUserMetadataRequest
+{
+    [JsonPropertyName("playstyle")]
+    public IEnumerable<UserPlaystyle>? Playstyle { get; set; }
+
+    [JsonPropertyName("location")]
+    [MaxLength(32)]
+    public string? Location { get; set; } = null;
+
+    [JsonPropertyName("interest")]
+    [MaxLength(32)]
+    public string? Interest { get; set; } = null;
+
+    [JsonPropertyName("occupation")]
+    [MaxLength(32)]
+    public string? Occupation { get; set; } = null;
+
+    [JsonPropertyName("telegram")]
+    [MaxLength(32)]
+    public string? Telegram { get; set; } = null;
+
+    [JsonPropertyName("twitch")]
+    [MaxLength(32)]
+    public string? Twitch { get; set; } = null;
+
+    [JsonPropertyName("twitter")]
+    [MaxLength(32)]
+    public string? Twitter { get; set; } = null;
+
+    [JsonPropertyName("discord")]
+    [MaxLength(32)]
+    public string? Discord { get; set; } = null;
+
+    [JsonPropertyName("website")]
+    [MaxLength(200)]
+    public string? Website { get; set; } = null;
+}

--- a/Sunrise.API/Serializable/Response/FollowersResponse.cs
+++ b/Sunrise.API/Serializable/Response/FollowersResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.API.Serializable.Response;
+
+public class FollowersResponse(List<UserResponse> followers, int totalCount)
+{
+    [JsonPropertyName("followers")]
+    public List<UserResponse> Followers { get; set; } = followers;
+
+    [JsonPropertyName("total_count")]
+    public int TotalCount { get; set; } = totalCount;
+}

--- a/Sunrise.API/Serializable/Response/UserMetadataResponse.cs
+++ b/Sunrise.API/Serializable/Response/UserMetadataResponse.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+using Sunrise.Shared.Database.Models.Users;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Shared.Helpers;
+
+namespace Sunrise.API.Serializable.Response;
+
+public class UserMetadataResponse
+{
+    [JsonConstructor]
+    public UserMetadataResponse() { }
+
+    public UserMetadataResponse(UserMetadata metadata)
+    {
+        Playstyle = JsonStringFlagEnumHelper.SplitFlags(metadata.Playstyle);
+        Location = metadata.Location;
+        Interest = metadata.Interest;
+        Occupation = metadata.Occupation;
+        Telegram = metadata.Telegram;
+        Twitch = metadata.Twitch;
+        Twitter = metadata.Twitter;
+        Discord = metadata.Discord;
+        Website = metadata.Website;
+    }
+
+    [JsonPropertyName("playstyle")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public IEnumerable<UserPlaystyle> Playstyle { get; set; }
+
+    [JsonPropertyName("location")]
+    public string Location { get; set; }
+
+    [JsonPropertyName("interest")]
+    public string Interest { get; set; }
+
+    [JsonPropertyName("occupation")]
+    public string Occupation { get; set; }
+
+    [JsonPropertyName("telegram")]
+    public string Telegram { get; set; }
+
+    [JsonPropertyName("twitch")]
+    public string Twitch { get; set; }
+
+    [JsonPropertyName("twitter")]
+    public string Twitter { get; set; }
+
+    [JsonPropertyName("discord")]
+    public string Discord { get; set; }
+
+    [JsonPropertyName("website")]
+    public string Website { get; set; }
+}

--- a/Sunrise.API/Serializable/Response/UserRelationsCountersResponse.cs
+++ b/Sunrise.API/Serializable/Response/UserRelationsCountersResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.API.Serializable.Response;
+
+public class UserRelationsCountersResponse(int followers, int following)
+{
+    [JsonPropertyName("followers")]
+    public int Followers { get; set; } = followers;
+
+    [JsonPropertyName("following")]
+    public int Following { get; set; } = following;
+}

--- a/Sunrise.Server.Tests/API/UserController/ApiUserEditUserMetadataTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserEditUserMetadataTests.cs
@@ -1,0 +1,210 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Sunrise.API.Serializable.Request;
+using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Beatmaps;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Shared.Helpers;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.API.UserController;
+
+public class ApiUserEditUserMetadataTests : ApiTest
+{
+    private readonly MockService _mocker = new();
+
+    [Fact]
+    public async Task TestEditUserMetadataUserWithoutAuthToken()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+        
+        // Act
+        var response = await client.PostAsync($"user/edit/metadata", new StringContent(""));
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("authorize to access", responseContent?.Error);
+    }
+
+    [Fact]
+    public async Task TestEditUserMetadataInvalidBody()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+        
+        var json = "{{\"string\":\"123\"}}";
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync($"user/edit/metadata", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("fields are invalid", responseError?.Error);
+    }
+    
+    [Fact]
+    public async Task TestEditMetadataWithInvalidLocationLength()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+
+        var newLocation = _mocker.GetRandomString(33);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/metadata",
+            new EditUserMetadataRequest
+            {
+                Location = newLocation,
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("fields are invalid", responseError?.Error);
+    }
+    
+    [Fact]
+    public async Task TestEditUserMetadata()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+        
+        var userMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (userMetadata is null)
+            throw new Exception("User metadata not found");
+
+        userMetadata = _mocker.User.SetRandomUserMetadata(userMetadata);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/metadata",
+            new EditUserMetadataRequest
+            {
+                Location = userMetadata.Location,
+                Discord = userMetadata.Discord,
+                Interest = userMetadata.Interest,
+                Occupation = userMetadata.Occupation,
+                Playstyle = JsonStringFlagEnumHelper.SplitFlags(userMetadata.Playstyle),
+                Telegram = userMetadata.Telegram,
+                Twitch = userMetadata.Twitch,
+                Twitter = userMetadata.Twitter,
+                Website = userMetadata.Website,
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var newUserMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (newUserMetadata is null)
+            throw new Exception("User metadata not found");
+
+        userMetadata.User = null!; // Ignore for comparison
+        
+        Assert.Equivalent(newUserMetadata, userMetadata);
+    }
+    
+    [Fact]
+    public async Task TestEditUserMetadataPartly()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+        
+        var userMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (userMetadata is null)
+            throw new Exception("User metadata not found");
+
+        userMetadata.Playstyle = UserPlaystyle.Tablet & UserPlaystyle.Mouse;
+        userMetadata.Occupation = "Testing 123";
+        userMetadata.Interest = "Testing 123";
+        
+        await Database.Users.Metadata.UpdateUserMetadata(userMetadata);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/metadata",
+            new EditUserMetadataRequest
+            {
+                Playstyle = JsonStringFlagEnumHelper.SplitFlags(UserPlaystyle.None),
+                Occupation = "",
+            });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var newUserMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (newUserMetadata is null)
+            throw new Exception("User metadata not found");
+        
+        Assert.Equivalent(newUserMetadata.Playstyle, UserPlaystyle.None);
+        Assert.Equivalent(newUserMetadata.Occupation, "");
+        Assert.Equivalent(newUserMetadata.Interest, "Testing 123");
+    }
+
+
+    [Fact]
+    public async Task TestEditUserMetadataWithActiveRestriction()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var tokens = await GetUserAuthTokens(user);
+        client.UseUserAuthToken(tokens);
+        
+        var userMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (userMetadata is null)
+            throw new Exception("User metadata not found");
+
+        userMetadata = _mocker.User.SetRandomUserMetadata(userMetadata);
+        
+        var result = await Database.Users.Moderation.RestrictPlayer(user.Id, null, "Test");
+        if (result.IsFailure)
+            throw new Exception(result.Error);
+
+        // Act
+        var response = await client.PostAsJsonAsync("user/edit/metadata",
+            new EditUserMetadataRequest
+            {
+                Location = userMetadata.Location,
+                Discord = userMetadata.Discord,
+                Interest = userMetadata.Interest,
+                Occupation = userMetadata.Occupation,
+                Playstyle = JsonStringFlagEnumHelper.SplitFlags(userMetadata.Playstyle),
+                Telegram = userMetadata.Telegram,
+                Twitch = userMetadata.Twitch,
+                Twitter = userMetadata.Twitter,
+                Website = userMetadata.Website,
+            });
+        
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+        var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("authorize to access", responseError?.Error);
+    }
+}

--- a/Sunrise.Server.Tests/API/UserController/ApiUserFriendsTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserFriendsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Users;
 using Sunrise.Tests.Abstracts;
 using Sunrise.Tests.Extensions;
 using Sunrise.Tests.Services.Mock;
@@ -70,9 +71,14 @@ public class ApiUserFriendsTests : ApiTest
         await CreateTestUser(randomUser);
 
         var randomUserResponse = new UserResponse(Sessions, randomUser);
+        
+        var relationship = await Database.Users.Relationship.GetUserRelationship(user.Id, randomUser.Id);
+        if (relationship == null)
+            return;
 
-        user.AddFriend(randomUser.Id);
-        await Database.Users.UpdateUser(user);
+        relationship.Relation = UserRelation.Friend;
+
+        await Database.Users.Relationship.UpdateUserRelationship(relationship);
 
         // Act
         var response = await client.GetAsync("user/friends");
@@ -105,7 +111,15 @@ public class ApiUserFriendsTests : ApiTest
             randomUser.Username = $"username_{i.ToString()}";
 
             await CreateTestUser(randomUser);
-            user.AddFriend(randomUser.Id);
+          
+            var relationship = await Database.Users.Relationship.GetUserRelationship(user.Id, randomUser.Id);
+            if (relationship == null)
+                return;
+
+            relationship.Relation = UserRelation.Friend;
+
+            await Database.Users.Relationship.UpdateUserRelationship(relationship);
+            
             await Database.Users.UpdateUser(user);
 
             lastAddedUserId = randomUser.Id;
@@ -137,8 +151,15 @@ public class ApiUserFriendsTests : ApiTest
 
         var randomUser = _mocker.User.GetRandomUser();
         await CreateTestUser(randomUser);
+        
+        var relationship = await Database.Users.Relationship.GetUserRelationship(user.Id, randomUser.Id);
+        if (relationship == null)
+            return;
 
-        user.AddFriend(randomUser.Id);
+        relationship.Relation = UserRelation.Friend;
+
+        await Database.Users.Relationship.UpdateUserRelationship(relationship);
+  
         await Database.Users.UpdateUser(user);
 
         await Database.Users.Moderation.RestrictPlayer(randomUser.Id, null, "Test");

--- a/Sunrise.Server.Tests/API/UserController/ApiUserGetFriendStatusTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserGetFriendStatusTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Users;
 using Sunrise.Tests.Abstracts;
 using Sunrise.Tests.Extensions;
 using Sunrise.Tests.Services.Mock;
@@ -90,14 +91,24 @@ public class ApiUserGetFriendStatusTests : ApiTest
 
         if (isFollowedByYou)
         {
-            user.AddFriend(requestedUser.Id);
-            await Database.Users.UpdateUser(user);
+            var relationship = await Database.Users.Relationship.GetUserRelationship(user.Id, requestedUser.Id);
+            if (relationship == null)
+                return;
+
+            relationship.Relation = UserRelation.Friend;
+
+            await Database.Users.Relationship.UpdateUserRelationship(relationship);
         }
 
         if (isFollowingYou)
         {
-            requestedUser.AddFriend(user.Id);
-            await Database.Users.UpdateUser(requestedUser);
+            var relationship = await Database.Users.Relationship.GetUserRelationship( requestedUser.Id, user.Id);
+            if (relationship == null)
+                return;
+
+            relationship.Relation = UserRelation.Friend;
+
+            await Database.Users.Relationship.UpdateUserRelationship(relationship);
         }
 
         // Act

--- a/Sunrise.Server.Tests/API/UserController/ApiUserGetUserFriendsCountTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserGetUserFriendsCountTests.cs
@@ -1,0 +1,157 @@
+﻿using System.Net;
+using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.API.UserController;
+
+public class ApiUserGetUserFriendsCountTests : ApiTest
+{
+    private readonly MockService _mocker = new();
+
+    [Fact]
+    public async Task TestGetUserFriendsCountUserNotFound()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var userId = _mocker.GetRandomInteger(minInt: 2);
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/friends/count");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("User not found", responseContent?.Error);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("test")]
+    public async Task TestGetUserFriendsCountInvalidRoute(string userId)
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/friends/count");
+
+        // Assert
+        Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task TestGetUserFriendsCount(bool isUserFollows, bool isUserBeingFollowed)
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var requestedUser = await CreateTestUser();
+
+        if (isUserFollows)
+        {
+            var userRelationship = await Database.Users.Relationship.GetUserRelationship(user.Id, requestedUser.Id);
+            if (userRelationship == null)
+                return;
+
+            userRelationship.Relation = UserRelation.Friend;
+
+            await Database.Users.Relationship.UpdateUserRelationship(userRelationship);
+        }
+
+        if (isUserBeingFollowed)
+        {
+            var requestedUserRelationship = await Database.Users.Relationship.GetUserRelationship(requestedUser.Id, user.Id);
+            if (requestedUserRelationship == null)
+                return;
+
+            requestedUserRelationship.Relation = UserRelation.Friend;
+
+            await Database.Users.Relationship.UpdateUserRelationship(requestedUserRelationship);
+        }
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/friends/count");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<UserRelationsCountersResponse>();
+
+        Assert.NotNull(responseContent);
+
+        Assert.Equal(isUserFollows ? 1 : 0, responseContent.Following);
+        Assert.Equal(isUserBeingFollowed ? 1 : 0, responseContent.Followers);
+    }
+
+    [Fact]
+    public async Task TestGetUserFriendsCountIgnoreRestrictedUsers()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var requestedUser = await CreateTestUser();
+
+        var userRelationship = await Database.Users.Relationship.GetUserRelationship(user.Id, requestedUser.Id);
+        if (userRelationship == null)
+            return;
+
+        userRelationship.Relation = UserRelation.Friend;
+
+        await Database.Users.Relationship.UpdateUserRelationship(userRelationship);
+
+        var requestedUserRelationship = await Database.Users.Relationship.GetUserRelationship(user.Id, requestedUser.Id);
+        if (requestedUserRelationship == null)
+            return;
+
+        requestedUserRelationship.Relation = UserRelation.Friend;
+
+        await Database.Users.Relationship.UpdateUserRelationship(requestedUserRelationship);
+
+        await Database.Users.Moderation.RestrictPlayer(requestedUser.Id, null, "Test");
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/friends/count");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<UserRelationsCountersResponse>();
+
+        Assert.NotNull(responseContent);
+
+        Assert.Equal(0, responseContent.Following);
+        Assert.Equal(0, responseContent.Followers);
+    }
+
+    [Fact]
+    public async Task TestGetUserFriendsCountWithActiveRestriction()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+
+        await Database.Users.Moderation.RestrictPlayer(user.Id, null, "Test");
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/friends/count");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("User not found", responseContent?.Error);
+    }
+}

--- a/Sunrise.Server.Tests/API/UserController/ApiUserGetUserMetadataTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserGetUserMetadataTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Net;
+using Sunrise.API.Serializable.Response;
+using Sunrise.Shared.Enums.Beatmaps;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.API.UserController;
+
+public class ApiUserGetUserMetadataTests : ApiTest
+{
+    private readonly MockService _mocker = new();
+
+    [Fact]
+    public async Task TestGetUserMetadataNotFound()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var userId = _mocker.GetRandomInteger(minInt: 2);
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/metadata");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("User not found", responseContent?.Error);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("test")]
+    public async Task TestGetUserMetadataInvalidUserId(string userId)
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/metadata");
+
+        // Assert
+        Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+    
+    [Fact]
+    public async Task TestGetUserMetadata()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        var userMetadata = await Database.Users.Metadata.GetUserMetadata(user.Id);
+        if (userMetadata is null)
+            throw new Exception("User metadata not found");
+
+        userMetadata = _mocker.User.SetRandomUserMetadata(userMetadata);
+
+        var arrangeUserMetadataResult = await Database.Users.Metadata.UpdateUserMetadata(userMetadata);
+
+        if (arrangeUserMetadataResult.IsFailure)
+            throw new Exception(arrangeUserMetadataResult.Error);
+
+        var userMetadataData = new UserMetadataResponse(userMetadata);
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/metadata");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var responseMetadata = await response.Content.ReadFromJsonAsyncWithAppConfig<UserMetadataResponse>();
+        Assert.NotNull(responseMetadata);
+
+        Assert.Equivalent(userMetadataData, responseMetadata);
+    }
+
+
+    [Fact]
+    public async Task TestGetUserMetadataRestrictedNotFound()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+
+        await Database.Users.Moderation.RestrictPlayer(user.Id, null, "Test");
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/metadata");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ErrorResponse>();
+        Assert.Contains("User is restricted", responseContent?.Error);
+    }
+}

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -208,6 +208,8 @@ public static class Bootstrap
         builder.Services.AddScoped<UserStatsSnapshotService>();
         builder.Services.AddScoped<UserStatsRanksService>();
 
+        builder.Services.AddScoped<UserMetadataService>();
+
         builder.Services.AddScoped<UserModerationService>();
         builder.Services.AddScoped<UserMedalsService>();
         builder.Services.AddScoped<UserFavouritesService>();

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -210,6 +210,8 @@ public static class Bootstrap
 
         builder.Services.AddScoped<UserMetadataService>();
 
+        builder.Services.AddScoped<UserRelationshipService>();
+
         builder.Services.AddScoped<UserModerationService>();
         builder.Services.AddScoped<UserMedalsService>();
         builder.Services.AddScoped<UserFavouritesService>();

--- a/Sunrise.Server/Packets/PacketHandlers/FriendsAddHandler.cs
+++ b/Sunrise.Server/Packets/PacketHandlers/FriendsAddHandler.cs
@@ -3,6 +3,7 @@ using HOPEless.Bancho.Objects;
 using Sunrise.Server.Attributes;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database;
+using Sunrise.Shared.Enums.Users;
 using Sunrise.Shared.Objects.Sessions;
 
 namespace Sunrise.Server.Packets.PacketHandlers;
@@ -13,16 +14,16 @@ public class FriendsAddHandler : IPacketHandler
     public async Task Handle(BanchoPacket packet, Session session)
     {
         var friendId = new BanchoInt(packet.Data);
-        
+
         using var scope = ServicesProviderHolder.CreateScope();
         var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
-                
-        var user = await database.Users.GetUser(session.UserId);
-        if (user == null)
+
+        var relationship = await database.Users.Relationship.GetUserRelationship(session.UserId, friendId.Value);
+        if (relationship == null)
             return;
 
-        user.AddFriend(friendId.Value);
+        relationship.Relation = UserRelation.Friend;
 
-        await database.Users.UpdateUser(user);
+        await database.Users.Relationship.UpdateUserRelationship(relationship);
     }
 }

--- a/Sunrise.Server/Packets/PacketHandlers/FriendsRemoveHandler.cs
+++ b/Sunrise.Server/Packets/PacketHandlers/FriendsRemoveHandler.cs
@@ -3,6 +3,7 @@ using HOPEless.Bancho.Objects;
 using Sunrise.Server.Attributes;
 using Sunrise.Shared.Application;
 using Sunrise.Shared.Database;
+using Sunrise.Shared.Enums.Users;
 using Sunrise.Shared.Objects.Sessions;
 
 namespace Sunrise.Server.Packets.PacketHandlers;
@@ -16,13 +17,13 @@ public class FriendsRemoveHandler : IPacketHandler
 
         using var scope = ServicesProviderHolder.CreateScope();
         var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
-                
-        var user = await database.Users.GetUser(session.UserId);
-        if (user == null)
+
+        var relationship = await database.Users.Relationship.GetUserRelationship(session.UserId, friendId.Value);
+        if (relationship == null)
             return;
 
-        user.RemoveFriend(friendId.Value);
+        relationship.Relation = UserRelation.None;
 
-        await database.Users.UpdateUser(user);
+        await database.Users.Relationship.UpdateUserRelationship(relationship);
     }
 }

--- a/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250508213243_AddUserMetadataTable")]
+    partial class AddUserMetadataTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.cs
+++ b/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using MySql.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserMetadataTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_metadata",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    Playstyle = table.Column<int>(type: "int", nullable: false),
+                    Location = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Interest = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Occupation = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Telegram = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Twitch = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Twitter = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Discord = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Website = table.Column<string>(type: "varchar(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_metadata", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_metadata_user_UserId",
+                        column: x => x.UserId,
+                        principalTable: "user",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_metadata_UserId",
+                table: "user_metadata",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_metadata");
+        }
+    }
+}

--- a/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250509040239_AddUserRelationshipTable")]
+    partial class AddUserRelationshipTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -302,6 +305,10 @@ namespace Sunrise.Shared.Database.Migrations
                         .IsRequired()
                         .HasColumnType("varchar(255)")
                         .UseCollation("utf8mb4_unicode_ci");
+
+                    b.Property<string>("Friends")
+                        .IsRequired()
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("LastOnlineTime")
                         .HasColumnType("datetime(6)");

--- a/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using MySql.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserRelationshipTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_relationship",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    TargetId = table.Column<int>(type: "int", nullable: false),
+                    Relation = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_relationship", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_relationship_user_TargetId",
+                        column: x => x.TargetId,
+                        principalTable: "user",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_user_relationship_user_UserId",
+                        column: x => x.UserId,
+                        principalTable: "user",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_relationship_TargetId",
+                table: "user_relationship",
+                column: "TargetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_relationship_UserId_TargetId",
+                table: "user_relationship",
+                columns: new[] { "UserId", "TargetId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_relationship");
+        }
+    }
+}

--- a/Sunrise.Shared/Database/Migrations/20250509040446_MigrateUsersFriendsToRelationshipTable.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509040446_MigrateUsersFriendsToRelationshipTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250509040446_MigrateUsersFriendsToRelationshipTable")]
+    partial class MigrateUsersFriendsToRelationshipTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -302,6 +305,10 @@ namespace Sunrise.Shared.Database.Migrations
                         .IsRequired()
                         .HasColumnType("varchar(255)")
                         .UseCollation("utf8mb4_unicode_ci");
+
+                    b.Property<string>("Friends")
+                        .IsRequired()
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("LastOnlineTime")
                         .HasColumnType("datetime(6)");

--- a/Sunrise.Shared/Database/Migrations/20250509040446_MigrateUsersFriendsToRelationshipTable.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509040446_MigrateUsersFriendsToRelationshipTable.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Sunrise.Shared.Enums.Users;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class MigrateUsersFriendsToRelationshipTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var query = $"""
+                          INSERT INTO user_relationship (UserId, TargetId, Relation)
+                          SELECT
+                          u.Id AS UserId,
+                          CAST(f.value AS SIGNED) AS TargetId,
+                          {(int)UserRelation.Friend} AS Relation
+                          FROM user u
+                          JOIN JSON_TABLE(
+                          CONCAT('["', REPLACE(TRIM(BOTH ',' FROM u.Friends), ',', '","'), '"]'),
+                          '$[*]' COLUMNS (
+                          value VARCHAR(255) PATH '$'
+                          )
+                          ) AS f
+                          WHERE u.Friends IS NOT NULL
+                          AND TRIM(u.Friends) <> ''
+                          AND f.value REGEXP '^[0-9]+$';
+                          """;
+            
+            migrationBuilder.Sql(query);
+        }
+                
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}
+                

--- a/Sunrise.Shared/Database/Migrations/20250509042335_RemoveOldUserStringFieldInUser.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509042335_RemoveOldUserStringFieldInUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -10,9 +11,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250509042335_RemoveOldUserStringFieldInUser")]
+    partial class RemoveOldUserStringFieldInUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sunrise.Shared/Database/Migrations/20250509042335_RemoveOldUserStringFieldInUser.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509042335_RemoveOldUserStringFieldInUser.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveOldUserStringFieldInUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Friends",
+                table: "user");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Friends",
+                table: "user",
+                type: "longtext",
+                nullable: false);
+        }
+    }
+}

--- a/Sunrise.Shared/Database/Models/Users/User.cs
+++ b/Sunrise.Shared/Database/Models/Users/User.cs
@@ -25,12 +25,14 @@ public class User
     public UserPrivilege Privilege { get; set; } = UserPrivilege.User;
     public DateTime RegisterDate { get; set; } = DateTime.UtcNow;
     public DateTime LastOnlineTime { get; set; } = DateTime.UtcNow;
-    public string Friends { get; set; } = string.Empty;
     public UserAccountStatus AccountStatus { get; set; } = UserAccountStatus.Active;
     public DateTime SilencedUntil { get; set; } = DateTime.MinValue;
     public GameMode DefaultGameMode { get; set; } = GameMode.Standard;
 
     public ICollection<UserFile> UserFiles { get; set; } = new List<UserFile>();
+
+    public ICollection<UserRelationship> UserInitiatedRelationships { get; set; } = new List<UserRelationship>();
+    public ICollection<UserRelationship> UserReceivedRelationships { get; set; } = new List<UserRelationship>();
 
     public ICollection<UserStats> UserStats { get; set; } = new List<UserStats>();
 
@@ -47,29 +49,7 @@ public class User
 
     [NotMapped]
     public string BannerUrl => $"https://a.{Configuration.Domain}/banner/{Id}{(BannerRecord != null ? $"?{new DateTimeOffset(BannerRecord.UpdatedAt).ToUnixTimeMilliseconds()}" : "")}";
-
-    [NotMapped]
-    public List<int> FriendsList => Friends.Split(',')
-        .Where(x => !string.IsNullOrEmpty(x))
-        .Select(int.Parse)
-        .ToList();
-
-    public void AddFriend(int friendId)
-    {
-        if (FriendsList.Contains(friendId))
-            return;
-
-        Friends += $",{friendId}";
-    }
-
-    public void RemoveFriend(int friendId)
-    {
-        if (!FriendsList.Contains(friendId))
-            return;
-
-        Friends = string.Join(',', FriendsList.Where(x => x != friendId));
-    }
-
+    
     public PlayerRank GetPrivilegeRank()
     {
         var privilegeRank = PlayerRank.Default;

--- a/Sunrise.Shared/Database/Models/Users/UserMetadata.cs
+++ b/Sunrise.Shared/Database/Models/Users/UserMetadata.cs
@@ -1,0 +1,44 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Sunrise.Shared.Enums.Users;
+
+namespace Sunrise.Shared.Database.Models.Users;
+
+[Table("user_metadata")]
+[Index(nameof(UserId))]
+public class UserMetadata
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    [ForeignKey("UserId")]
+    public User User { get; set; }
+
+    public UserPlaystyle Playstyle { get; set; } = UserPlaystyle.None;
+
+    [StringLength(32)]
+    public string Location { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Interest { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Occupation { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Telegram { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Twitch { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Twitter { get; set; } = string.Empty;
+
+    [StringLength(32)]
+    public string Discord { get; set; } = string.Empty;
+
+    [StringLength(200)]
+    public string Website { get; set; } = string.Empty;
+}

--- a/Sunrise.Shared/Database/Models/Users/UserRelationship.cs
+++ b/Sunrise.Shared/Database/Models/Users/UserRelationship.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+using Sunrise.Shared.Enums.Users;
+
+namespace Sunrise.Shared.Database.Models.Users;
+
+[Table("user_relationship")]
+[Index(nameof(UserId), nameof(TargetId))]
+public class UserRelationship
+{
+    public int Id { get; set; }
+
+    [ForeignKey("UserId")]
+    public User User { get; set; }
+
+    public int UserId { get; set; }
+
+    [ForeignKey("TargetId")]
+    public User Target { get; set; }
+
+    public int TargetId { get; set; }
+
+    public UserRelation Relation { get; set; } = UserRelation.None;
+}

--- a/Sunrise.Shared/Database/Repositories/UserRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/UserRepository.cs
@@ -16,6 +16,7 @@ public class UserRepository(
     Lazy<DatabaseService> databaseService,
     SunriseDbContext dbContext,
     UserStatsService userStatsService,
+    UserRelationshipService userRelationshipService,
     UserModerationService userModerationService,
     UserMetadataService userMetadataService,
     UserMedalsService userMedalsService,
@@ -25,6 +26,7 @@ public class UserRepository(
 {
     private readonly ILogger _logger = logger;
 
+    public UserRelationshipService Relationship { get; } = userRelationshipService;
     public UserStatsService Stats { get; } = userStatsService;
     public UserFavouritesService Favourites { get; } = userFavouritesService;
     public UserMedalsService Medals { get; } = userMedalsService;
@@ -140,22 +142,6 @@ public class UserRepository(
             .ToListAsync(cancellationToken: ct);
 
         return user;
-    }
-
-    public async Task<(List<User> Users, int TotalCount)> GetUsersFriends(User user, QueryOptions? options = null, CancellationToken ct = default)
-    {
-        var friendsQuery = dbContext.Users
-            .Where(u => user.FriendsList.Contains(u.Id))
-            .FilterValidUsers();
-
-        var totalCount = options?.IgnoreCountQueryIfExists == false ? await friendsQuery.CountAsync(cancellationToken: ct) : -1;
-
-        var friends = await friendsQuery
-            .IncludeUserThumbnails()
-            .UseQueryOptions(options)
-            .ToListAsync(cancellationToken: ct);
-
-        return (friends, totalCount);
     }
 
     public async Task<int> CountUsers(CancellationToken ct = default)

--- a/Sunrise.Shared/Database/Repositories/UserRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/UserRepository.cs
@@ -17,6 +17,7 @@ public class UserRepository(
     SunriseDbContext dbContext,
     UserStatsService userStatsService,
     UserModerationService userModerationService,
+    UserMetadataService userMetadataService,
     UserMedalsService userMedalsService,
     UserFavouritesService userFavouritesService,
     UserFileService userFileService,
@@ -30,6 +31,7 @@ public class UserRepository(
     public UserModerationService Moderation { get; } = userModerationService;
     public UserFileService Files { get; } = userFileService;
     public UserGradesService Grades { get; } = userGradesService;
+    public UserMetadataService Metadata { get; } = userMetadataService;
 
     public async Task<Result> AddUser(User user)
     {

--- a/Sunrise.Shared/Database/Services/Users/UserFavouritesService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserFavouritesService.cs
@@ -52,7 +52,7 @@ public class UserFavouritesService(SunriseDbContext dbContext)
             .Where(ufb => ufb.UserId == userId)
             .AsNoTracking();
 
-        var totalCount = options?.IgnoreCountQueryIfExists == false ? await beatmapsQuery.CountAsync(cancellationToken: ct) : -1;
+        var totalCount = options?.IgnoreCountQueryIfExists == true ? -1 : await beatmapsQuery.CountAsync(cancellationToken: ct);
 
         var beatmapsIds = await beatmapsQuery
             .UseQueryOptions(options)

--- a/Sunrise.Shared/Database/Services/Users/UserMetadataService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserMetadataService.cs
@@ -1,0 +1,57 @@
+using CSharpFunctionalExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sunrise.Shared.Database.Extensions;
+using Sunrise.Shared.Database.Models.Users;
+using Sunrise.Shared.Utils;
+
+namespace Sunrise.Shared.Database.Services.Users;
+
+public class UserMetadataService(
+    ILogger<UserMetadataService> logger,
+    Lazy<DatabaseService> databaseService,
+    SunriseDbContext dbContext)
+{
+    private readonly ILogger _logger = logger;
+
+    private async Task<Result> AddUserMetadata(UserMetadata userMetadata)
+    {
+        return await ResultUtil.TryExecuteAsync(async () =>
+        {
+            dbContext.UserMetadata.Add(userMetadata);
+            await dbContext.SaveChangesAsync();
+        });
+    }
+
+    public async Task<Result> UpdateUserMetadata(UserMetadata userMetadata)
+    {
+        return await ResultUtil.TryExecuteAsync(async () =>
+        {
+            dbContext.UpdateEntity(userMetadata);
+            await dbContext.SaveChangesAsync();
+        });
+    }
+
+    public async Task<UserMetadata?> GetUserMetadata(int userId, CancellationToken ct = default)
+    {
+        var metadata = await dbContext.UserMetadata.Where(e => e.UserId == userId).FirstOrDefaultAsync(cancellationToken: ct);
+
+        if (metadata == null)
+        {
+            var user = await databaseService.Value.Users.GetUser(userId, ct: ct);
+            if (user == null) return null;
+
+            _logger.LogInformation($"User metadata not found for user (id: {userId}). Creating new metadata.");
+
+            metadata = new UserMetadata
+            {
+                UserId = user.Id,
+                User = user
+            };
+
+            await AddUserMetadata(metadata);
+        }
+
+        return metadata;
+    }
+}

--- a/Sunrise.Shared/Database/Services/Users/UserRelationshipService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserRelationshipService.cs
@@ -1,0 +1,90 @@
+using CSharpFunctionalExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Sunrise.Shared.Database.Extensions;
+using Sunrise.Shared.Database.Models.Users;
+using Sunrise.Shared.Database.Objects;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Shared.Utils;
+
+namespace Sunrise.Shared.Database.Services.Users;
+
+public class UserRelationshipService(
+    ILogger<UserRelationshipService> logger,
+    Lazy<DatabaseService> databaseService,
+    SunriseDbContext dbContext)
+{
+    private readonly ILogger _logger = logger;
+
+    private async Task<Result> AddUserRelationship(UserRelationship userRelationship)
+    {
+        return await ResultUtil.TryExecuteAsync(async () =>
+        {
+            dbContext.UserRelationships.Add(userRelationship);
+            await dbContext.SaveChangesAsync();
+        });
+    }
+
+    public async Task<Result> UpdateUserRelationship(UserRelationship userRelationship)
+    {
+        return await ResultUtil.TryExecuteAsync(async () =>
+        {
+            dbContext.UpdateEntity(userRelationship);
+            await dbContext.SaveChangesAsync();
+        });
+    }
+
+    public async Task<UserRelationship?> GetUserRelationship(int userId, int targetId, CancellationToken ct = default)
+    {
+        var relationship = await dbContext.UserRelationships
+            .Where(r => 
+                r.UserId == userId &&
+                r.User.AccountStatus != UserAccountStatus.Restricted &&
+                r.TargetId == targetId && 
+                r.Target.AccountStatus != UserAccountStatus.Restricted)
+            .FirstOrDefaultAsync(cancellationToken: ct);
+
+        if (relationship == null)
+        {
+            var user = await databaseService.Value.Users.GetValidUser(userId, ct: ct);
+            if (user == null) return null;
+            
+            var target = await databaseService.Value.Users.GetValidUser(targetId, ct: ct);
+            if (target == null) return null;
+
+            relationship = new UserRelationship
+            {
+                UserId = user.Id,
+                TargetId = target.Id,
+            };
+
+            await AddUserRelationship(relationship);
+        }
+
+        return relationship;
+    }
+
+    public async Task<(List<UserRelationship> friends, int totalCount)> GetUserFriends(int userId, QueryOptions? options = null, CancellationToken ct = default)
+    {
+        var query = dbContext.UserRelationships
+            .Where(r => r.UserId == userId && r.Relation == UserRelation.Friend && r.Target.AccountStatus != UserAccountStatus.Restricted);
+
+        var totalCount = options?.IgnoreCountQueryIfExists == true ? -1 : await query.CountAsync(cancellationToken: ct);
+
+        var friends = await query.UseQueryOptions(options).ToListAsync(cancellationToken: ct);
+
+        return (friends, totalCount);
+    }
+
+    public async Task<(List<UserRelationship> friends, int totalCount)> GetUserFollowers(int userId, QueryOptions? options = null, CancellationToken ct = default)
+    {
+        var query = dbContext.UserRelationships
+            .Where(r => r.TargetId == userId && r.Relation == UserRelation.Friend && r.User.AccountStatus != UserAccountStatus.Restricted);
+
+        var totalCount = options?.IgnoreCountQueryIfExists == true ? -1 : await query.CountAsync(cancellationToken: ct);
+
+        var friends = await query.UseQueryOptions(options).ToListAsync(cancellationToken: ct);
+
+        return (friends, totalCount);
+    }
+}

--- a/Sunrise.Shared/Database/SunriseDbContext.cs
+++ b/Sunrise.Shared/Database/SunriseDbContext.cs
@@ -17,6 +17,7 @@ public class SunriseDbContext : DbContext
     }
 
     public DbSet<User> Users { get; set; }
+    public DbSet<UserRelationship> UserRelationships { get; set; }
     public DbSet<UserFavouriteBeatmap> UserFavouriteBeatmaps { get; set; }
     public DbSet<UserMedals> UserMedals { get; set; }
     public DbSet<UserMetadata> UserMetadata { get; set; }
@@ -45,6 +46,18 @@ public class SunriseDbContext : DbContext
         modelBuilder.Entity<User>()
             .Property(u => u.Email)
             .UseCollation("utf8mb4_unicode_ci");
+
+        modelBuilder.Entity<UserRelationship>()
+            .HasOne(ur => ur.User)
+            .WithMany(u => u.UserInitiatedRelationships)
+            .HasForeignKey(ur => ur.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<UserRelationship>()
+            .HasOne(ur => ur.Target)
+            .WithMany(u => u.UserReceivedRelationships)
+            .HasForeignKey(ur => ur.TargetId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/Sunrise.Shared/Database/SunriseDbContext.cs
+++ b/Sunrise.Shared/Database/SunriseDbContext.cs
@@ -19,6 +19,7 @@ public class SunriseDbContext : DbContext
     public DbSet<User> Users { get; set; }
     public DbSet<UserFavouriteBeatmap> UserFavouriteBeatmaps { get; set; }
     public DbSet<UserMedals> UserMedals { get; set; }
+    public DbSet<UserMetadata> UserMetadata { get; set; }
     public DbSet<UserStats> UserStats { get; set; }
     public DbSet<UserGrades> UserGrades { get; set; }
     public DbSet<UserStatsSnapshot> UserStatsSnapshot { get; set; }

--- a/Sunrise.Shared/Enums/Users/UserPlaystyle.cs
+++ b/Sunrise.Shared/Enums/Users/UserPlaystyle.cs
@@ -1,0 +1,11 @@
+﻿namespace Sunrise.Shared.Enums.Users;
+
+[Flags]
+public enum UserPlaystyle
+{
+    None = 0,
+    Mouse = 1 << 0,
+    Keyboard = 1 << 1,
+    Tablet = 1 << 2,
+    TouchScreen = 1 << 3
+}

--- a/Sunrise.Shared/Enums/Users/UserRelation.cs
+++ b/Sunrise.Shared/Enums/Users/UserRelation.cs
@@ -1,0 +1,8 @@
+﻿namespace Sunrise.Shared.Enums.Users;
+
+public enum UserRelation
+{
+    None = 0,
+    Friend = 1,
+    Blocked = 2
+}

--- a/Sunrise.Shared/Helpers/JsonStringFlagEnumHelper.cs
+++ b/Sunrise.Shared/Helpers/JsonStringFlagEnumHelper.cs
@@ -1,0 +1,37 @@
+﻿namespace Sunrise.Shared.Helpers;
+
+public static class JsonStringFlagEnumHelper
+{
+    public static TEnum CombineFlags<TEnum>(IEnumerable<TEnum>? values) where TEnum : struct, Enum
+    {
+        if (!typeof(TEnum).IsDefined(typeof(FlagsAttribute), false))
+            throw new InvalidOperationException($"{typeof(TEnum).Name} must have [Flags] attribute.");
+
+        var result = (values ?? []).Aggregate(0, (current, value) => current | Convert.ToInt32(value));
+
+        return (TEnum)Enum.ToObject(typeof(TEnum), result);
+    }
+
+    public static IEnumerable<TEnum> SplitFlags<TEnum>(TEnum value) where TEnum : struct, Enum
+    {
+        if (!typeof(TEnum).IsDefined(typeof(FlagsAttribute), false))
+            throw new InvalidOperationException($"{typeof(TEnum).Name} must have [Flags] attribute.");
+
+        var intValue = Convert.ToInt32(value);
+
+        foreach (TEnum flag in Enum.GetValues(typeof(TEnum)))
+        {
+            var flagValue = Convert.ToInt32(flag);
+
+            if (flagValue != 0 && (intValue & flagValue) == flagValue)
+            {
+                yield return flag;
+            }
+        }
+
+        if (intValue == 0 && Enum.IsDefined(typeof(TEnum), 0))
+        {
+            yield return (TEnum)Enum.ToObject(typeof(TEnum), 0);
+        }
+    }
+}

--- a/Sunrise.Shared/Objects/Sessions/Session.cs
+++ b/Sunrise.Shared/Objects/Sessions/Session.cs
@@ -158,13 +158,13 @@ public class Session : BaseSession
         _helper.WritePacket(type, data);
     }
 
-    public void SendFriendsList()
+    public void SendFriendsList(List<int> friendsIds)
     {
         var user = GetSessionUser();
         if (user == null)
             return;
 
-        _helper.WritePacket(PacketType.ServerFriendsList, user.FriendsList);
+        _helper.WritePacket(PacketType.ServerFriendsList, friendsIds);
     }
 
     public void SendMultiMatchJoinFail()

--- a/Sunrise.Shared/Objects/Sessions/Session.cs
+++ b/Sunrise.Shared/Objects/Sessions/Session.cs
@@ -160,10 +160,6 @@ public class Session : BaseSession
 
     public void SendFriendsList(List<int> friendsIds)
     {
-        var user = GetSessionUser();
-        if (user == null)
-            return;
-
         _helper.WritePacket(PacketType.ServerFriendsList, friendsIds);
     }
 

--- a/Sunrise.Tests/Services/Mock/Services/MockUserService.cs
+++ b/Sunrise.Tests/Services/Mock/Services/MockUserService.cs
@@ -43,6 +43,23 @@ public class MockUserService(MockService service)
 
         return grades;
     }
+    
+    public UserMetadata SetRandomUserMetadata(UserMetadata metadata)
+    {
+        metadata.Location = service.GetRandomString(32);
+        metadata.Occupation = service.GetRandomString(32);
+        metadata.Interest = service.GetRandomString(32);
+        
+        metadata.Discord = service.GetRandomString(32);
+        metadata.Telegram = service.GetRandomString(32);
+        metadata.Twitch = service.GetRandomString(32);
+        metadata.Twitter = service.GetRandomString(32);
+        metadata.Website = service.GetRandomString(200);
+
+        metadata.Playstyle = GetRandomUserPlaystyle();
+
+        return metadata;
+    }
 
     public User GetRandomUser()
     {
@@ -76,6 +93,13 @@ public class MockUserService(MockService service)
         var random = new Random();
         var values = Enum.GetValues(typeof(CountryCode));
         return (short)values.GetValue(random.Next(values.Length))!;
+    }
+    
+    public UserPlaystyle GetRandomUserPlaystyle()
+    {
+        var random = new Random();
+        var values = Enum.GetValues(typeof(UserPlaystyle));
+        return (UserPlaystyle)values.GetValue(random.Next(values.Length))!;
     }
 
     public string GetRandomPassword()


### PR DESCRIPTION
This PR is focused on adding users metadata and users relationship on the table. Duh. 


## Adding user metadata

> [!NOTE]  
> Users can now set their playstyle, their personal data and social profiles, which all would be shown at the Sunset frontend.

- We add new database table `user_metadata`, where we store user playstyle and other metadata.
- To this, we add new API endpoints: `/user/{id}/metadata` and `edit/metadata` to view and edit metadata table.

## Adding user relationship
> [!NOTE]  
> This is a direct replacement of `Friends` row in `user` table. It was fine for getting only users friends, but in this PR we adding new ability to view users followers, and by this we would be required to check every users `Friends` row to get users followers, which quite counter productive. Relationship table includes one to many relationship of `user` to `target`, with future ability to even have custom relation as `Blocked`.

- We add new database table `user_relationship`, where we store all users relationships.
- We have migrations which would migrate current users friends, before removing `Friends` row from `user`.
- To this, we add new API endpoints: `/user/{id}/followers`, to get list of users followers, and `user/{id}/friends/count`, to get count of users friends and followers.

---

Tests are added for new endpoints, related endpoints which were changed, also got their tests updated.

![image](https://github.com/user-attachments/assets/1f0ae1b7-e4f8-47c1-b069-dff24919baf0)
> me and all my 0 followers
