### PR TITLE
/np now sends current mods while playing

### DIFF
--- a/Sunrise.Server/Repositories/ChatCommandRepository.cs
+++ b/Sunrise.Server/Repositories/ChatCommandRepository.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 using HOPEless.Bancho;
 using HOPEless.Bancho.Objects;

--- a/Sunrise.Server/Repositories/ChatCommandRepository.cs
+++ b/Sunrise.Server/Repositories/ChatCommandRepository.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using HOPEless.Bancho;
 using HOPEless.Bancho.Objects;
@@ -8,6 +9,7 @@ using Sunrise.Shared.Application;
 using Sunrise.Shared.Database;
 using Sunrise.Shared.Extensions.Scores;
 using Sunrise.Shared.Objects;
+using Sunrise.Shared.Objects.Chat;
 using Sunrise.Shared.Objects.Sessions;
 using Sunrise.Shared.Repositories;
 
@@ -159,9 +161,9 @@ public static class ChatCommandRepository
 
         var beatmapsAction = new[]
         {
-            "is listening to",
-            "is watching",
-            "is playing"
+            ChatBeatmapActions.IS_LISTENING_TO,
+            ChatBeatmapActions.IS_WATCHING,
+            ChatBeatmapActions.IS_PLAYING
         };
 
         if (beatmapsAction.Any(x => action?.StartsWith(x) == true))
@@ -170,11 +172,16 @@ public static class ChatCommandRepository
 
             var beatmapId = int.TryParse(message.Split('/')[5].Split(' ')[0], out var id) ? id : 0;
 
-            var mods = action?.StartsWith("is watching") == true
-                ? session.Spectating?.Attributes.Status.CurrentMods
-                : Mods.None;
+            Mods mods;
+            
+            if (action?.StartsWith(ChatBeatmapActions.IS_WATCHING) == true)
+                mods = session.Spectating?.Attributes.Status.CurrentMods ?? Mods.None;
+            else if (action?.StartsWith(ChatBeatmapActions.IS_PLAYING) == true)
+                mods = session.Attributes.Status.CurrentMods;
+            else
+                mods = Mods.None;
 
-            return ("beatmap", [beatmapId.ToString(), mods?.GetModsString() ?? string.Empty]);
+            return ("beatmap", [beatmapId.ToString(), mods.GetModsString() ?? string.Empty]);
         }
 
         return (null, null);

--- a/Sunrise.Shared/Objects/Chat/ChatBeatmapActions.cs
+++ b/Sunrise.Shared/Objects/Chat/ChatBeatmapActions.cs
@@ -1,0 +1,8 @@
+﻿namespace Sunrise.Shared.Objects.Chat;
+
+public class ChatBeatmapActions
+{
+    public static string IS_PLAYING = "is playing";
+    public static string IS_WATCHING = "is watching";
+    public static string IS_LISTENING_TO = "is listening to";
+}


### PR DESCRIPTION
include mods in /np to SunshineBot to calculate pp. (actually😎 now sends mods when using /np while playing a map)

- Fixed mods not being included in /np action while playing.
- Refactored hardcoded action strings into a new object with constants.
![WHkQnhk](https://github.com/user-attachments/assets/0816794d-4a53-45d5-9fd6-e37c0120fc9d)


🤣🤣🤣🤣🤣🤣