### PR TITLE
Websocket improvements

### DIFF
--- a/Sunrise.API/Controllers/WebSocketController.cs
+++ b/Sunrise.API/Controllers/WebSocketController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Sunrise.API.Objects;
 using Sunrise.Shared.Attributes;
 using Sunrise.Shared.Services;
 using WebSocketManager = Sunrise.API.Managers.WebSocketManager;
@@ -8,9 +9,11 @@ namespace Sunrise.API.Controllers;
 
 [Route("/ws")]
 [Subdomain("api")]
-[ApiExplorerSettings(IgnoreApi = true)]
 public class WebSocketController(WebSocketManager webSocketManager) : ControllerBase
 {
+    [HttpGet]
+    [EndpointDescription("WebSocket route. Sends server events as stringified JSON on connection.")]
+    [ProducesResponseType(typeof(WebSocketMessage), StatusCodes.Status200OK)]
     public async Task Get(CancellationToken cancellationToken)
     {
         if (HttpContext.WebSockets.IsWebSocketRequest)

--- a/Sunrise.API/Controllers/WebSocketController.cs
+++ b/Sunrise.API/Controllers/WebSocketController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Sunrise.Shared.Attributes;
+using Sunrise.Shared.Services;
 using WebSocketManager = Sunrise.API.Managers.WebSocketManager;
 
 namespace Sunrise.API.Controllers;
@@ -15,7 +16,8 @@ public class WebSocketController(WebSocketManager webSocketManager) : Controller
         if (HttpContext.WebSockets.IsWebSocketRequest)
         {
             using var webSocket = await HttpContext.WebSockets.AcceptWebSocketAsync();
-            await webSocketManager.HandleConnection(webSocket, cancellationToken);
+            var userIp = RegionService.GetUserIpAddress(Request);
+            await webSocketManager.HandleConnection(userIp, webSocket, cancellationToken);
         }
         else
         {

--- a/Sunrise.API/Objects/WebSocketMessage.cs
+++ b/Sunrise.API/Objects/WebSocketMessage.cs
@@ -1,16 +1,20 @@
 ﻿using System.Text.Json;
 using Sunrise.API.Enums;
+using Sunrise.Shared.Application;
 
 namespace Sunrise.API.Objects;
 
 public class WebSocketMessage(WebSocketEventType type, object message)
 {
     private readonly object _message = message;
+    private JsonSerializerOptions JsonSerializerOptions { get; } = Configuration.SystemTextJsonOptions;
+
     public WebSocketEventType MessageType { get; } = type;
 
     public string Data => JsonSerializer.Serialize(new
-    {
-        type = MessageType,
-        data = _message
-    });
+        {
+            type = MessageType,
+            data = _message
+        },
+        JsonSerializerOptions);
 }

--- a/Sunrise.API/Serializable/Response/CustomBeatmapStatusChangeResponse.cs
+++ b/Sunrise.API/Serializable/Response/CustomBeatmapStatusChangeResponse.cs
@@ -7,8 +7,6 @@ public class CustomBeatmapStatusChangeResponse
 {
     public CustomBeatmapStatusChangeResponse(BeatmapResponse beatmap, BeatmapStatusWeb newStatus, BeatmapStatusWeb oldStatus, UserResponse batUser)
     {
-
-
         Beatmap = beatmap;
         User = batUser;
         NewStatus = newStatus;

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http.Timeouts;
 using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.OpenApi.Models;
 using Prometheus;
 using Scalar.AspNetCore;
 using StackExchange.Redis;
@@ -28,6 +29,7 @@ using Sunrise.Shared.Extensions;
 using Sunrise.Shared.Repositories;
 using Sunrise.Shared.Repositories.Multiplayer;
 using Sunrise.Shared.Services;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using AssetService = Sunrise.API.Services.AssetService;
 using AuthService = Sunrise.API.Services.AuthService;
 using WebSocketManager = Sunrise.API.Managers.WebSocketManager;
@@ -62,7 +64,9 @@ public static class Bootstrap
             c.EnableAnnotations();
             c.SupportNonNullableReferenceTypes();
             c.NonNullableReferenceTypesAsRequired();
-
+            
+            c.DocumentFilter<GenerateAdditionalOpenApiSchema>();
+            
             c.AddJwtAuth();
         });
 
@@ -349,5 +353,15 @@ public static class Bootstrap
             : base(serviceProvider.GetRequiredService<T>)
         {
         }
+    }
+}
+
+public class GenerateAdditionalOpenApiSchema : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        var schema = context.SchemaGenerator.GenerateSchema(typeof(CustomBeatmapStatusChangeResponse), context.SchemaRepository);
+        
+        swaggerDoc.Components.Schemas.TryAdd(nameof(CustomBeatmapStatusChangeResponse), schema);
     }
 }


### PR DESCRIPTION
This PR implements multiple WS improvements.

Changelog:
- Add concurrent limit for websockets from a single IP (Currently set to 4).
- Use server's JsonOptions for serialization. (tldr: Enum's are now parsed to strings)
- Add ResponseType for websocket to generate all possible websocket messages type with OpenAPI.

![image](https://github.com/user-attachments/assets/cfc9453a-b811-4ebc-9412-fcb8deac02c6)
