### PR TITLE
Add `user/{id}/previous-usernames` API endpoint

### DIFF
--- a/Sunrise.API/Controllers/UserController.cs
+++ b/Sunrise.API/Controllers/UserController.cs
@@ -725,8 +725,8 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
             return Problem(title: ApiErrorResponse.Title.UnableToChangeUsername, detail: error, statusCode: StatusCodes.Status400BadRequest);
 
         var lastUsernameChange = await database.Events.Users.GetLastUsernameChangeEvent(user.Id);
-        if (lastUsernameChange != null && lastUsernameChange.Time.AddHours(1) > DateTime.UtcNow)
-            return Problem(title: ApiErrorResponse.Title.UnableToChangeUsername, detail: ApiErrorResponse.Detail.ChangeUsernameOnCooldown(lastUsernameChange.Time.AddHours(1)), statusCode: StatusCodes.Status400BadRequest);
+        if (lastUsernameChange != null && lastUsernameChange.Time.AddDays(Configuration.UsernameChangeCooldownInDays) > DateTime.UtcNow)
+            return Problem(title: ApiErrorResponse.Title.UnableToChangeUsername, detail: ApiErrorResponse.Detail.ChangeUsernameOnCooldown(lastUsernameChange.Time.AddDays(Configuration.UsernameChangeCooldownInDays)), statusCode: StatusCodes.Status400BadRequest);
 
         var foundUserByUsername = await database.Users.GetUser(username: request.NewUsername);
         if (foundUserByUsername != null && foundUserByUsername.IsActive())

--- a/Sunrise.API/Serializable/Response/PreviousUsernamesResponse.cs
+++ b/Sunrise.API/Serializable/Response/PreviousUsernamesResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Sunrise.API.Serializable.Response;
+
+public class PreviousUsernamesResponse
+{
+    public PreviousUsernamesResponse(List<string> usernames)
+    {
+        Usernames = usernames;
+    }
+
+    [JsonConstructor]
+    public PreviousUsernamesResponse()
+    {
+    }
+
+    [JsonPropertyName("usernames")]
+    public List<string> Usernames { get; set; }
+}

--- a/Sunrise.Server.Tests/API/UserController/ApiUserGetUserPreviousUsernamesTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserGetUserPreviousUsernamesTests.cs
@@ -1,0 +1,151 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Sunrise.API.Objects.Keys;
+using Sunrise.API.Serializable.Response;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Extensions;
+using Sunrise.Tests.Services.Mock;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.API.UserController;
+
+public class ApiUserGetUserPreviousUsernamesTests : ApiTest
+{
+    private readonly MockService _mocker = new();
+
+    [Fact]
+    public async Task TestGetUserPreviousUsernamesUserNotFound()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var userId = _mocker.GetRandomInteger();
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/previous-usernames");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ProblemDetails>();
+        Assert.Contains(ApiErrorResponse.Detail.UserNotFound, responseContent?.Detail);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("test")]
+    public async Task TestGetUserPreviousUsernameInvalidRoute(string userId)
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        // Act
+        var response = await client.GetAsync($"user/{userId}/previous-usernames");
+
+        // Assert
+        Assert.NotEqual(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TestGetUserPreviousUsernames()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+
+        var originalUsername = user.Username;
+
+        var arrangeUserChangeUsernameResult = await Database.Users.UpdateUserUsername(user, user.Username, _mocker.GetRandomString());
+        if (arrangeUserChangeUsernameResult.IsFailure)
+            throw new Exception(arrangeUserChangeUsernameResult.Error);
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/previous-usernames");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var responsePreviousUsernames = await response.Content.ReadFromJsonAsyncWithAppConfig<PreviousUsernamesResponse>();
+        Assert.NotNull(responsePreviousUsernames);
+
+        Assert.Equal(responsePreviousUsernames.Usernames, [originalUsername]);
+    }
+
+    [Fact]
+    public async Task TestGetUserPreviousUsernamesShowOnlyRecent()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var arrangeUserChangeUsernameResult = await Database.Users.UpdateUserUsername(user, user.Username, i.ToString());
+            if (arrangeUserChangeUsernameResult.IsFailure)
+                throw new Exception(arrangeUserChangeUsernameResult.Error);
+        }
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/previous-usernames");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var responsePreviousUsernames = await response.Content.ReadFromJsonAsyncWithAppConfig<PreviousUsernamesResponse>();
+        Assert.NotNull(responsePreviousUsernames);
+
+        Assert.Equal(responsePreviousUsernames.Usernames, ["8", "7", "6"]);
+    }
+    
+    [Fact]
+    public async Task TestGetUserPreviousUsernamesIgnoreFilteredUsernames()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+        
+        var badUsername = "badUsername";
+        
+        var arrangeUserChangeToBadUsernameResult = await Database.Users.UpdateUserUsername(user, user.Username, badUsername);
+        if (arrangeUserChangeToBadUsernameResult.IsFailure)
+            throw new Exception(arrangeUserChangeToBadUsernameResult.Error);
+
+        var arrangeUserFilterUsernameResult = await Database.Users.UpdateUserUsername(user, badUsername, $"filtered_{user.Id}");
+        if (arrangeUserFilterUsernameResult.IsFailure)
+            throw new Exception(arrangeUserFilterUsernameResult.Error);
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/previous-usernames");
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var responsePreviousUsernames = await response.Content.ReadFromJsonAsyncWithAppConfig<PreviousUsernamesResponse>();
+        Assert.NotNull(responsePreviousUsernames);
+
+        Assert.DoesNotContain(badUsername, responsePreviousUsernames.Usernames);
+    }
+
+    [Fact]
+    public async Task TestGetUserPreviousUsernameRestrictedUserNotFound()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("api");
+
+        var user = await CreateTestUser();
+
+        await Database.Users.Moderation.RestrictPlayer(user.Id, null, "Test");
+
+        // Act
+        var response = await client.GetAsync($"user/{user.Id}/previous-usernames");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var responseContent = await response.Content.ReadFromJsonAsyncWithAppConfig<ProblemDetails>();
+        Assert.Contains(ApiErrorResponse.Detail.UserIsRestricted, responseContent?.Detail);
+    }
+}

--- a/Sunrise.Server.Tests/API/UserController/ApiUserUsernameChangeTests.cs
+++ b/Sunrise.Server.Tests/API/UserController/ApiUserUsernameChangeTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Microsoft.AspNetCore.Mvc;
 using Sunrise.API.Objects.Keys;
 using Sunrise.API.Serializable.Request;
+using Sunrise.Shared.Application;
 using Sunrise.Shared.Enums.Users;
 using Sunrise.Shared.Extensions.Users;
 using Sunrise.Tests.Abstracts;
@@ -169,7 +170,7 @@ public class ApiUserUsernameChangeTests : ApiTest
 
 
         var responseError = await response.Content.ReadFromJsonAsyncWithAppConfig<ProblemDetails>();
-        Assert.Contains(ApiErrorResponse.Detail.ChangeUsernameOnCooldown(lastUsernameChange.Time.AddHours(1)), responseError?.Detail);
+        Assert.Contains(ApiErrorResponse.Detail.ChangeUsernameOnCooldown(lastUsernameChange.Time.AddDays(Configuration.UsernameChangeCooldownInDays)), responseError?.Detail);
     }
 
     [Theory]

--- a/Sunrise.Server/appsettings.Development.json
+++ b/Sunrise.Server/appsettings.Development.json
@@ -10,6 +10,7 @@
     "ObservatoryUrl": "localhost:3333",
     "OnMaintenance": false,
     "CountryChangeCooldownInDays": 90,
+    "UsernameChangeCooldownInDays": 30,
     "RateLimit": {
       "CallsPerWindow": 200,
       "Window": 10,
@@ -37,7 +38,7 @@
     "CacheLifeTime": 600,
     "UseCache": true,
     "UseRedisAsSecondCachingForDatabase": true,
-    "ClearCacheOnStartup": true
+    "ClearCacheOnStartup": false
   },
   "Hangfire": {
     "UseHangfireServer": false,

--- a/Sunrise.Server/appsettings.Production.json.example
+++ b/Sunrise.Server/appsettings.Production.json.example
@@ -11,6 +11,7 @@
     "ObservatoryUrl": "host.docker.internal:3333",
     "OnMaintenance": false,
     "CountryChangeCooldownInDays": 90,
+    "UsernameChangeCooldownInDays": 30,
     "RateLimit": {
       "CallsPerWindow": 200,
       "Window": 10,

--- a/Sunrise.Server/appsettings.Tests.json
+++ b/Sunrise.Server/appsettings.Tests.json
@@ -21,6 +21,7 @@
     "ObservatoryUrl": "jsonplaceholder.typicode.com",
     "OnMaintenance": false,
     "CountryChangeCooldownInDays": 90,
+    "UsernameChangeCooldownInDays": 30,
     "RateLimit": {
       "CallsPerWindow": 100,
       "Window": 10,

--- a/Sunrise.Shared/Application/Configuration.cs
+++ b/Sunrise.Shared/Application/Configuration.cs
@@ -82,6 +82,9 @@ public static class Configuration
     public static int CountryChangeCooldownInDays =>
         Config.GetSection("General").GetValue<int?>("CountryChangeCooldownInDays") ?? 90;
     
+    public static int UsernameChangeCooldownInDays =>
+        Config.GetSection("General").GetValue<int?>("UsernameChangeCooldownInDays") ?? 30;
+    
     public static int GeneralWindow =>
         Config.GetSection("General").GetSection("RateLimit").GetValue<int?>("Window") ?? 10;
 

--- a/Sunrise.Shared/Database/Services/Events/UserEventService.cs
+++ b/Sunrise.Shared/Database/Services/Events/UserEventService.cs
@@ -91,6 +91,15 @@ public class UserEventService(SunriseDbContext dbContext)
             .FirstOrDefaultAsync(cancellationToken: ct);
     }
 
+    public async Task<List<EventUser>> GetUserPreviousUsernameChangeEvents(int userId, QueryOptions? options = null, CancellationToken ct = default)
+    {
+        return await dbContext.EventUsers
+            .Where(x => x.UserId == userId && x.EventType == UserEventType.ChangeUsername)
+            .OrderByDescending(x => x.Id)
+            .UseQueryOptions(options)
+            .ToListAsync(cancellationToken: ct);
+    }
+
     public async Task<Result> AddUserChangeUsernameEvent(int userId, string ip, string oldUsername, string newUsername, int? updatedById = null)
     {
         return await ResultUtil.TryExecuteAsync(async () =>
@@ -126,7 +135,7 @@ public class UserEventService(SunriseDbContext dbContext)
         var userEvent = await dbContext.EventUsers
             .AsNoTracking().Include(eventUser => eventUser.User)
             .FirstOrDefaultAsync(x => x.Ip == ip && x.EventType == UserEventType.Register, ct);
-        
+
         return userEvent?.User;
     }
 
@@ -148,7 +157,7 @@ public class UserEventService(SunriseDbContext dbContext)
                 UpdatedById = updatedById
             });
 
-            
+
             dbContext.EventUsers.Add(changeCountryEvent);
             await dbContext.SaveChangesAsync();
         });

--- a/Sunrise.Shared/Objects/Keys/RequestKey.cs
+++ b/Sunrise.Shared/Objects/Keys/RequestKey.cs
@@ -21,6 +21,8 @@ public static class RequestType
     public const string UsernameChange = "username/change";
     public const string CountryChange = "country/change";
 
+    public const string UserPreviousUsernames = "{id:int}/previous-usernames";
+
     // Bancho controller
     public const string BanchoProcess = "/";
 

--- a/Sunrise.Shared/Objects/Serializable/Events/UserUsernameChanged.cs
+++ b/Sunrise.Shared/Objects/Serializable/Events/UserUsernameChanged.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sunrise.Shared.Objects.Serializable.Events;
+
+public class UserUsernameChanged
+{
+    [JsonPropertyName("NewUsername")]
+    public required string NewUsername { get; set; }
+
+    [JsonPropertyName("OldUsername")]
+    public required string OldUsername { get; set; }
+
+    [JsonPropertyName("UpdatedById")]
+    public int? UpdatedById { get; set; }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

We implement new API endpoint to see previous 3 users usernames.

We also remove hardcoded check for 1 hour cooldown to change username and replace it with `UsernameChangeCooldownInDays` config value.

Frontend PR is coming

----
![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExMTJhbnF3Z3VoOTB2dGF1MHJ6c2d5aTU0MHpkbXI1dzI1MGE2bDRjbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3tjwyuvfLDK9mMwaV4/giphy.gif)


<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif -->
