### PR TITLE
Add ability to hide users previous usernames on request

### DIFF
--- a/Sunrise.API/Controllers/UserController.cs
+++ b/Sunrise.API/Controllers/UserController.cs
@@ -353,7 +353,15 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
             ct);
 
         var usernames = previousUsernames.Select(e => e.GetData<UserUsernameChanged>())
-            .Where(data => data != null && !data.NewUsername.Contains("filtered"))
+            .Where(data =>
+            {
+                if (data == null) return false;
+
+                var isUsernameFiltered = data.NewUsername.Contains("filtered");
+                var isUsernameHidden = data.IsHiddenFromPreviousUsernames != null && data.IsHiddenFromPreviousUsernames.Value;
+
+                return !isUsernameFiltered && !isUsernameHidden;
+            })
             .Select(data => data?.OldUsername ?? "Unknown").ToList();
 
         return Ok(new PreviousUsernamesResponse(usernames));

--- a/Sunrise.Server/Commands/ChatCommands/Moderation/HidePreviousUsername.cs
+++ b/Sunrise.Server/Commands/ChatCommands/Moderation/HidePreviousUsername.cs
@@ -1,0 +1,50 @@
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Shared.Application;
+using Sunrise.Shared.Database;
+using Sunrise.Shared.Database.Models.Events;
+using Sunrise.Shared.Database.Objects;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Shared.Objects;
+using Sunrise.Shared.Objects.Serializable.Events;
+using Sunrise.Shared.Objects.Sessions;
+
+namespace Sunrise.Server.Commands.ChatCommands.Moderation;
+
+[ChatCommand("hideprevioususername", requiredPrivileges: UserPrivilege.Admin)]
+public class HidePreviousUsername : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length < 2)
+        {
+            ChatCommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}hideprevioususername <username change event id> <is hidden>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var eventId))
+        {
+            ChatCommandRepository.SendMessage(session, "Invalid event id.");
+            return;
+        }
+        
+        if (!bool.TryParse(args[1], out var isHidden))
+        {
+            ChatCommandRepository.SendMessage(session, "Invalid is hidden value. Use true or false.");
+            return;
+        }
+        
+        using var scope = ServicesProviderHolder.CreateScope();
+        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
+
+        var changeUsernameEventVisibilityResult = await database.Events.Users.SetUserChangeUsernameEventVisibility(eventId, isHidden);
+
+        if (changeUsernameEventVisibilityResult.IsFailure)
+        {
+            ChatCommandRepository.SendMessage(session, $"Failed to change event visibility: {changeUsernameEventVisibilityResult.Error}");
+            return;
+        }
+
+        ChatCommandRepository.SendMessage(session, $"Successfully changed event visibility. Event Id: {eventId}");
+    }
+}

--- a/Sunrise.Server/Commands/ChatCommands/Moderation/UserPreviousUsernames.cs
+++ b/Sunrise.Server/Commands/ChatCommands/Moderation/UserPreviousUsernames.cs
@@ -1,0 +1,68 @@
+using Sunrise.Server.Attributes;
+using Sunrise.Server.Repositories;
+using Sunrise.Shared.Application;
+using Sunrise.Shared.Database;
+using Sunrise.Shared.Database.Models.Events;
+using Sunrise.Shared.Database.Objects;
+using Sunrise.Shared.Enums.Users;
+using Sunrise.Shared.Objects;
+using Sunrise.Shared.Objects.Serializable.Events;
+using Sunrise.Shared.Objects.Sessions;
+
+namespace Sunrise.Server.Commands.ChatCommands.Moderation;
+
+[ChatCommand("userprevioususernames", requiredPrivileges: UserPrivilege.Admin)]
+public class UserPreviousUsernames : IChatCommand
+{
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
+    {
+        if (args == null || args.Length < 1)
+        {
+            ChatCommandRepository.SendMessage(session, $"Usage: {Configuration.BotPrefix}userprevioususernames <user id>");
+            return;
+        }
+
+        if (!int.TryParse(args[0], out var userId))
+        {
+            ChatCommandRepository.SendMessage(session, "Invalid user id.");
+            return;
+        }
+
+        using var scope = ServicesProviderHolder.CreateScope();
+        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
+
+
+        var user = await database.Users.GetUser(userId);
+
+        if (user == null)
+        {
+            ChatCommandRepository.SendMessage(session, "User not found.");
+            return;
+        }
+
+        var previousUsernames = await database.Events.Users.GetUserPreviousUsernameChangeEvents(user.Id,
+            new QueryOptions(true, new Pagination(1, 3))
+            {
+                QueryModifier = query => query.Cast<EventUser>().OrderByDescending(e => e.Id)
+            });
+
+        var usernames = previousUsernames.Select(e => e.GetData<UserUsernameChanged>())
+            .Where(u => u != null)
+            .Select((data, idx) =>
+            {
+                var isUsernameFiltered = data!.NewUsername.Contains("filtered");
+                var isUsernameHidden = data.IsHiddenFromPreviousUsernames != null && data.IsHiddenFromPreviousUsernames.Value;
+
+                return $"Event Id: {previousUsernames[idx].Id} | {data.OldUsername} -> {data.NewUsername} | Shown as \"{data.OldUsername}\" (Is shown: {!isUsernameHidden && !isUsernameFiltered})";
+            }).ToList();
+
+
+        if (usernames.Count == 0)
+        {
+            ChatCommandRepository.SendMessage(session, "No previous usernames found.");
+            return;
+        }
+
+        ChatCommandRepository.SendMessage(session, $"Previous usernames for {user.Username}:\n{string.Join("\n", usernames)}");
+    }
+}

--- a/Sunrise.Server/Repositories/ChatCommandRepository.cs
+++ b/Sunrise.Server/Repositories/ChatCommandRepository.cs
@@ -51,9 +51,16 @@ public static class ChatCommandRepository
             case null or { IsGlobal: false } when message.Channel != Configuration.BotUsername:
                 return;
             case null:
+            {
+                var possibleCommands = GetAvailableCommands(session)
+                    .Where(x => x.Contains(command))
+                    .ToArray();
+                
                 SendMessage(session,
-                    $"Command {command} not found. Type {Configuration.BotPrefix}help for a list of available commands.");
+                    possibleCommands.Length > 0 ? $"Did you mean: !{string.Join(", !", possibleCommands)}? Type {Configuration.BotPrefix}help for a list of available commands." : $"Command {command} not found. Type {Configuration.BotPrefix}help for a list of available commands.");
+
                 return;
+            }
         }
 
         using var scope = ServicesProviderHolder.CreateScope();
@@ -175,7 +182,7 @@ public static class ChatCommandRepository
 
             if (action?.StartsWith(ChatBeatmapActions.IS_WATCHING) == true)
                 mods = session.Spectating?.Attributes.Status.CurrentMods ?? Mods.None;
-                
+
             if (action?.StartsWith(ChatBeatmapActions.IS_PLAYING) == true)
                 mods = session.Attributes.Status.CurrentMods;
 

--- a/Sunrise.Shared/Objects/Serializable/Events/UserUsernameChanged.cs
+++ b/Sunrise.Shared/Objects/Serializable/Events/UserUsernameChanged.cs
@@ -12,4 +12,7 @@ public class UserUsernameChanged
 
     [JsonPropertyName("UpdatedById")]
     public int? UpdatedById { get; set; }
+
+    [JsonPropertyName("IsHiddenFromPreviousUsernames")]
+    public bool? IsHiddenFromPreviousUsernames { get; set; }
 }


### PR DESCRIPTION
## Description

Some users change their username due to personal reasons and don't want them to be shown in a list of previous usernames.

This is why we implement two new admin commands: `!hideprevioususername` and `!userprevioususernames`
With this, users with admin rights can hide/reveal user's usernames from their previous usernames list on demand.

#### Small tweaks

I also added a simple check on user enter command event, to show a possible meant command if none was found:

<img width="1892" height="214" alt="image" src="https://github.com/user-attachments/assets/d0585ccd-922d-4eb8-8519-c54d169c8ed3" />

#### Tests
New test was introduced to check if hide functionality works as intended.

-----

![](https://media.tenor.com/L9J04TBp8XYAAAAi/collei-genshin-impact.gif)

