### PR TITLE
Show pp as ranked score if it's over clients limit

### DIFF
--- a/Sunrise.Server.Tests/Controllers/BanchoControllerTests.cs
+++ b/Sunrise.Server.Tests/Controllers/BanchoControllerTests.cs
@@ -1,12 +1,17 @@
+using HOPEless.Bancho;
+using HOPEless.Bancho.Objects;
+using Sunrise.Shared.Enums.Beatmaps;
+using Sunrise.Shared.Enums.Users;
 using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Services.Mock;
 using Sunrise.Tests.Utils;
 
 namespace Sunrise.Server.Tests.Controllers;
 
-public class BanchoControllerTests : DatabaseTest
+public class BanchoControllerGetTests : DatabaseTest
 {
     [Fact]
-    public async Task Get_ReturnsImage()
+    public async Task TestOnGetRequestReturnsImage()
     {
         // Arrange
         var client = App.CreateClient().UseClient("c");
@@ -17,5 +22,143 @@ public class BanchoControllerTests : DatabaseTest
         // Assert
         response.EnsureSuccessStatusCode();
         Assert.Equal("image/jpeg", response.Content.Headers.ContentType?.MediaType);
+    }
+}
+
+public class BanchoControllerPostTests : BanchoTest
+{
+    
+    private readonly MockService _mocker = new();
+    
+    [Fact]
+    public async Task TestOnInvalidPasshashRejectLogin()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+
+        var user = await CreateTestUser();
+
+        var loginRequest = _mocker.User.GetUserLoginRequest(user);
+        loginRequest.PassHash = "invalid_passhash";
+        
+        var authBody = GetUserBodyLoginRequest( loginRequest);
+        
+        // Act
+        var response = await client.PostAsync("/", new StringContent(authBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        
+        var responsePackets = await GetResponsePackets(response);
+        var serverLoginReplyPacket = responsePackets.FirstOrDefault(x => x.Type == PacketType.ServerLoginReply);
+        Assert.NotNull(serverLoginReplyPacket);
+        
+        Assert.Equal((int)LoginResponse.InvalidCredentials, new BanchoInt(serverLoginReplyPacket.Data).Value);
+    }
+    
+    [Fact]
+    public async Task TestReturnSuccessIfLoginRequestValid()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+        
+        var user = await CreateTestUser();
+        var authBody = GetUserBodyLoginRequest(_mocker.User.GetUserLoginRequest(user));
+        
+        // Act
+        var response = await client.PostAsync("/", new StringContent(authBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        
+        var responsePackets = await GetResponsePackets(response);
+        var serverLoginReplyPacket = responsePackets.FirstOrDefault(x => x.Type == PacketType.ServerLoginReply);
+        Assert.NotNull(serverLoginReplyPacket);
+        
+        // We expect the server to return the user ID on successful login
+        Assert.Equal(user.Id, new BanchoInt(serverLoginReplyPacket.Data).Value);
+    }
+    
+    [Fact]
+    public async Task TestReturnUserDataWithoutPerformanceOverflowIfLoginRequestValid()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+        
+        var user = await CreateTestUser();
+        var authBody = GetUserBodyLoginRequest(_mocker.User.GetUserLoginRequest(user));
+
+        var userStats = await Database.Users.Stats.GetUserStats(user.Id, GameMode.Standard);
+        Assert.NotNull(userStats);
+
+        userStats.PerformancePoints = _mocker.GetRandomDouble(false);
+        
+        await Database.Users.Stats.UpdateUserStats(userStats, user);
+        
+        // Act
+        var response = await client.PostAsync("/", new StringContent(authBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        
+        var responsePackets = await GetResponsePackets(response);
+        var serverUserDataPacket = responsePackets.FirstOrDefault(x =>
+        {
+            if (x.Type != PacketType.ServerUserData)
+                return false;
+            
+            var packetData = new BanchoUserData(x.Data);
+            return packetData.UserId == user.Id;
+        });
+        
+        Assert.NotNull(serverUserDataPacket);
+        
+        var responseData = new BanchoUserData(serverUserDataPacket.Data);
+        Assert.NotNull(responseData);
+        
+        Assert.Equal(user.Id, responseData.UserId);
+        Assert.Equal((short)userStats.PerformancePoints, responseData.Performance);
+    }
+    
+    [Fact]
+    public async Task TestReturnUserDataWithPerformanceOverflowIfLoginRequestValid()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+        
+        var user = await CreateTestUser();
+        var authBody = GetUserBodyLoginRequest(_mocker.User.GetUserLoginRequest(user));
+
+        var userStats = await Database.Users.Stats.GetUserStats(user.Id, GameMode.Standard);
+        Assert.NotNull(userStats);
+
+        userStats.PerformancePoints = _mocker.GetRandomDouble(false) + ushort.MaxValue;
+        
+        await Database.Users.Stats.UpdateUserStats(userStats, user);
+        
+        // Act
+        var response = await client.PostAsync("/", new StringContent(authBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        
+        var responsePackets = await GetResponsePackets(response);
+        var serverUserDataPacket = responsePackets.FirstOrDefault(x =>
+        {
+            if (x.Type != PacketType.ServerUserData)
+                return false;
+            
+            var packetData = new BanchoUserData(x.Data);
+            return packetData.UserId == user.Id;
+        });
+        
+        Assert.NotNull(serverUserDataPacket);
+        
+        var responseData = new BanchoUserData(serverUserDataPacket.Data);
+        Assert.NotNull(responseData);
+        
+        Assert.Equal(user.Id, responseData.UserId);
+        Assert.Equal(0, responseData.Performance);
+        Assert.Equal((long)userStats.PerformancePoints, responseData.RankedScore);
     }
 }

--- a/Sunrise.Server.Tests/Packets/PacketUserPresenceRequestTests.cs
+++ b/Sunrise.Server.Tests/Packets/PacketUserPresenceRequestTests.cs
@@ -1,0 +1,53 @@
+﻿using HOPEless.Bancho;
+using HOPEless.Bancho.Objects;
+using osu.Shared;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.Packets;
+
+public class PacketUserPresenceRequestTests : BanchoTest
+{
+    [Fact]
+    public async Task TestReturnExpectedPresence()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+
+        var user = await CreateTestUser();
+        var loginToken = await GetUserAuthOsuToken(client, user);
+        client.UseUserAuthOsuToken(loginToken);
+
+        var expectedPresence = new BanchoUserPresence
+        {
+            UserId = user.Id,
+            Username = user.Username,
+            UsesOsuClient = true,
+            Latitude = 0,
+            Longitude = 0,
+            Permissions = PlayerRank.Default,
+            Rank = 1,
+            Timezone = 0,
+            CountryCode = (byte)user.Country,
+            PlayMode = GameMode.Standard
+        };
+
+        PacketHelper.WritePacket(PacketType.ClientUserPresenceRequest, 0);
+        var requestBody = PacketHelper.GetBytesToSend();
+
+        // Act
+        var response = await client.PostAsync("/", new ByteArrayContent(requestBody));
+        
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var responsePackets = await GetResponsePackets(response);
+        var responsePacket = responsePackets.FirstOrDefault(x => x.Type == PacketType.ServerUserPresence);
+        Assert.NotNull(responsePacket);
+
+        var responseData = new BanchoUserPresence(responsePacket.Data);
+        Assert.NotNull(responseData);
+
+        Assert.Equivalent(expectedPresence, responseData);
+    }
+}

--- a/Sunrise.Shared/Objects/Sessions/UserAttributes.cs
+++ b/Sunrise.Shared/Objects/Sessions/UserAttributes.cs
@@ -85,7 +85,8 @@ public class UserAttributes
 
         var (globalRank, _) = await database.Users.Stats.Ranks.GetUserRanks(user, GetCurrentGameMode());
         var userRank = IsBot ? 0 : globalRank;
-        
+
+        // Note: osu! client expects short integer for performance points. So to avoid this limitation, we will send pp as ranked score if it's over the limit.
         var isPerformanceOverClientLimit = userStats.PerformancePoints > short.MaxValue;
 
         return new BanchoUserData

--- a/Sunrise.Tests/Abstracts/BanchoTest.cs
+++ b/Sunrise.Tests/Abstracts/BanchoTest.cs
@@ -1,0 +1,42 @@
+using HOPEless.Bancho;
+using Sunrise.Shared.Database.Models.Users;
+using Sunrise.Shared.Helpers;
+using Sunrise.Shared.Objects.Sessions;
+
+namespace Sunrise.Tests.Abstracts;
+
+public abstract class BanchoTest(bool useRedis = false) : DatabaseTest(useRedis)
+{
+    protected readonly PacketHelper PacketHelper = new();
+
+    protected string GetUserBodyLoginRequest(LoginRequest loginRequest)
+    {
+        string[] strings =
+        [
+            loginRequest.Username,
+            loginRequest.PassHash,
+            $"{loginRequest.Version}|{loginRequest.UtcOffset}|{(loginRequest.ShowCityLocation ? "1" : "0")}|{loginRequest.ClientHash}|{(loginRequest.BlockNonFriendPm ? "1" : "0")}"
+        ];
+
+        return string.Join('\n', strings);
+    }
+
+    protected async Task<List<BanchoPacket>> GetResponsePackets(HttpResponseMessage response)
+    {
+        await using var buffer = new MemoryStream();
+        await response.Content.CopyToAsync(buffer);
+        buffer.Seek(0, SeekOrigin.Begin);
+
+        return BanchoSerializer.DeserializePackets(buffer).ToList();
+    }
+
+    protected async Task<string> GetUserAuthOsuToken(HttpClient client, User user, LoginRequest? loginRequest = null)
+    {
+        var authBody = GetUserBodyLoginRequest(loginRequest ?? new LoginRequest(user.Username, user.Passhash, "version", 0, true, "", false));
+        var loginResponse = await client.PostAsync("/", new StringContent(authBody));
+
+        loginResponse.EnsureSuccessStatusCode();
+
+        return loginResponse.Headers.GetValues("cho-token").FirstOrDefault() ?? throw new Exception("Auth token not found");
+    }
+}

--- a/Sunrise.Tests/Services/Mock/MockService.cs
+++ b/Sunrise.Tests/Services/Mock/MockService.cs
@@ -31,6 +31,12 @@ public class MockService
         return new Random().Next(0, 2) == 1;
     }
 
+    public double GetRandomDouble(bool? negative = null)
+    {
+        var random = new Random();
+        return random.NextDouble() * (negative != null ? negative.Value ? -1 : 1 : GetRandomBoolean() ? -1 : 1);
+    }
+
     public string GetRandomString(int length = 16)
     {
         var baseString = $"{Guid.NewGuid():N}";

--- a/Sunrise.Tests/Services/Mock/Services/MockUserService.cs
+++ b/Sunrise.Tests/Services/Mock/Services/MockUserService.cs
@@ -1,6 +1,7 @@
 ﻿using Sunrise.Shared.Database.Models.Users;
 using Sunrise.Shared.Enums.Users;
 using Sunrise.Shared.Extensions.Users;
+using Sunrise.Shared.Objects.Sessions;
 
 namespace Sunrise.Tests.Services.Mock.Services;
 
@@ -119,5 +120,10 @@ public class MockUserService(MockService service)
     public string GetRandomEmail(string? username = null)
     {
         return $"{username ?? service.GetRandomString()}@mail.com";
+    }
+    
+    public LoginRequest GetUserLoginRequest(User user)
+    {
+        return new LoginRequest(user.Username, user.Passhash, "version", 0, true, "", false);
     }
 }

--- a/Sunrise.Tests/Utils/RequestUtil.cs
+++ b/Sunrise.Tests/Utils/RequestUtil.cs
@@ -18,6 +18,13 @@ public static class RequestUtil
         return client;
     }
 
+    public static HttpClient UseUserAuthOsuToken(this HttpClient client, string token)
+    {
+        client.DefaultRequestHeaders.Add("osu-token", token);
+
+        return client;
+    }
+
     public static HttpClient UseUserIp(this HttpClient client, string ip)
     {
         client.DefaultRequestHeaders.Add("X-Forwarded-For", ip);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Osu client expects pp to be `short`, which means pp has a hard limit of 32767. 
This behaviour is really unwanted for all possible servers which players can have pp over that limit.

To fix this, we are going to check if pp overflows `short` limit, and if so, we are going to show it as ranked score:
<img width="968" height="127" alt="image" src="https://github.com/user-attachments/assets/9b6ceec4-1946-4e24-b71d-8a14b6fca317" />

Fixes #81 

UPD: We also added test cases for user data packets + example test case for `UserPresence` packet.

----


<!--- Describe your changes in detail -->
![ezgif-45cdd1050a45f1](https://github.com/user-attachments/assets/e91be39d-7ab3-4183-bfa5-afce438d13a4)


<!--- Don't forget to add some funny or just cool image/gif -->
