### PR TITLE
Add new performance calculation algorithm

### DIFF
--- a/Sunrise.Server.Tests/Extensions/UserStatsExtensionsTests.cs
+++ b/Sunrise.Server.Tests/Extensions/UserStatsExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Sunrise.Shared.Extensions.Beatmaps;
 using Sunrise.Shared.Extensions.Users;
+using Sunrise.Shared.Objects;
 using Sunrise.Tests.Abstracts;
 using Sunrise.Tests.Services.Mock;
 using GameMode = Sunrise.Shared.Enums.Beatmaps.GameMode;
@@ -59,7 +60,77 @@ public class UserStatsExtensionsDatabaseTests : DatabaseTest
         var prevStats = userStats.Clone();
 
         // Act
-        await userStats.UpdateWithScore(score, oldScore, 100);
+        await userStats.UpdateWithScore(score, new UserPersonalBestScores(oldScore), 100);
+
+        // Assert
+        var shouldIncludeKatuGeki = (GameMode)score.GameMode.ToVanillaGameMode() is GameMode.Taiko or GameMode.Mania;
+        var expectedTotalHits = prevStats.TotalHits + score.Count300 + score.Count100 + score.Count50 + (shouldIncludeKatuGeki ? score.CountGeki + score.CountKatu : 0);
+
+        Assert.Equal(expectedTotalHits, userStats.TotalHits);
+        Assert.Equal(prevStats.PlayTime + 100, userStats.PlayTime);
+        Assert.Equal(prevStats.PlayCount + 1, userStats.PlayCount);
+        Assert.Equal(score.TotalScore, userStats.TotalScore);
+        Assert.Equal(score.TotalScore - oldScore.TotalScore, userStats.RankedScore);
+        Assert.Equal(score.MaxCombo, userStats.MaxCombo);
+
+        const double weightedTolerance = 0.5;
+        Assert.True(Math.Abs(prevStats.PerformancePoints + 100 - userStats.PerformancePoints) < weightedTolerance);
+        Assert.True(Math.Abs(score.Accuracy - userStats.Accuracy) < weightedTolerance);
+    }
+
+    [Fact]
+    public async Task TestUpdateWithScoreWithBetterRankedScoreUsingNewPerformanceCalculationAlgorithmUpdateRankedScoreOnly()
+    {
+        // Arrange
+        var user = await CreateTestUser();
+
+        var score = _mocker.Score.GetBestScoreableRandomScore();
+        score.LocalProperties.IsRanked = true;
+        score.PerformancePoints = 100;
+
+        var oldScore = _mocker.Score.GetBestScoreableRandomScore();
+        oldScore.TotalScore = score.TotalScore + 1;
+
+        var userStats = await Database.Users.Stats.GetUserStats(user.Id, score.GameMode);
+        var prevStats = userStats.Clone();
+
+        // Act
+        await userStats.UpdateWithScore(score, new UserPersonalBestScores(oldScore, oldScore), 100);
+
+        // Assert
+        var shouldIncludeKatuGeki = (GameMode)score.GameMode.ToVanillaGameMode() is GameMode.Taiko or GameMode.Mania;
+        var expectedTotalHits = prevStats.TotalHits + score.Count300 + score.Count100 + score.Count50 + (shouldIncludeKatuGeki ? score.CountGeki + score.CountKatu : 0);
+
+        Assert.Equal(expectedTotalHits, userStats.TotalHits);
+        Assert.Equal(prevStats.PlayTime + 100, userStats.PlayTime);
+        Assert.Equal(prevStats.PlayCount + 1, userStats.PlayCount);
+        Assert.Equal(score.TotalScore, userStats.TotalScore);
+        Assert.Equal(0, userStats.RankedScore); // No updates
+        Assert.Equal(score.MaxCombo, userStats.MaxCombo);
+
+        Assert.Equal(prevStats.PerformancePoints, userStats.PerformancePoints);
+        Assert.Equal(prevStats.Accuracy, userStats.Accuracy);
+    }
+
+    [Fact]
+    public async Task TestUpdateWithScoreWithBetterRankedScoreUsingNewPerformanceCalculationAlgorithmUpdateOnlyPerformancePoints()
+    {
+        // Arrange
+        var user = await CreateTestUser();
+
+        var score = _mocker.Score.GetBestScoreableRandomScore();
+        score.LocalProperties.IsRanked = true;
+        score.PerformancePoints = 100;
+
+        var oldScore = _mocker.Score.GetBestScoreableRandomScore();
+        oldScore.TotalScore = score.TotalScore + 1;
+        oldScore.PerformancePoints = score.PerformancePoints - 1;
+
+        var userStats = await Database.Users.Stats.GetUserStats(user.Id, score.GameMode);
+        var prevStats = userStats.Clone();
+
+        // Act
+        await userStats.UpdateWithScore(score, new UserPersonalBestScores(oldScore, oldScore), 100);
 
         // Assert
         var shouldIncludeKatuGeki = (GameMode)score.GameMode.ToVanillaGameMode() is GameMode.Taiko or GameMode.Mania;
@@ -94,7 +165,7 @@ public class UserStatsExtensionsDatabaseTests : DatabaseTest
         var prevStats = userStats.Clone();
 
         // Act
-        await userStats.UpdateWithScore(score, oldScore, 100);
+        await userStats.UpdateWithScore(score, new UserPersonalBestScores(oldScore), 100);
 
         // Assert
         var shouldIncludeKatuGeki = (GameMode)score.GameMode.ToVanillaGameMode() is GameMode.Taiko or GameMode.Mania;
@@ -182,7 +253,7 @@ public class UserStatsExtensionsTests : BaseTest
         var prevStats = userStats.Clone();
 
         // Act
-        await userStats.UpdateWithScore(score, oldScore, 100);
+        await userStats.UpdateWithScore(score, new UserPersonalBestScores(oldScore), 100);
 
         // Assert
         var shouldIncludeKatuGeki = (GameMode)score.GameMode.ToVanillaGameMode() is GameMode.Taiko or GameMode.Mania;

--- a/Sunrise.Server/Services/ScoreService.cs
+++ b/Sunrise.Server/Services/ScoreService.cs
@@ -200,11 +200,11 @@ public class ScoreService(BeatmapService beatmapService, DatabaseService databas
             await userStats.UpdateWithScore(score, prevUserPersonalBestScores, timeElapsed);
             userGrades.UpdateWithScore(score, prevUserPersonalBestScores?.BestScoreBasedByTotalScore);
 
-            if (prevUserPersonalBestScores?.BestScoreBasedByTotalScore != null && score.SubmissionStatus == SubmissionStatus.Best)
+            if (prevUserPersonalBestScoresWithSameMods?.BestScoreBasedByTotalScore != null && score.SubmissionStatus == SubmissionStatus.Best)
             {
                 // Best score shouldn't be failed, but adding this check just in case
-                prevUserPersonalBestScores.BestScoreBasedByTotalScore.SubmissionStatus = prevUserPersonalBestScores.BestScoreBasedByTotalScore.IsPassed ? SubmissionStatus.Submitted : SubmissionStatus.Failed;
-                await database.Scores.UpdateScore(prevUserPersonalBestScores.BestScoreBasedByTotalScore);
+                prevUserPersonalBestScoresWithSameMods.BestScoreBasedByTotalScore.SubmissionStatus = prevUserPersonalBestScoresWithSameMods.BestScoreBasedByTotalScore.IsPassed ? SubmissionStatus.Submitted : SubmissionStatus.Failed;
+                await database.Scores.UpdateScore(prevUserPersonalBestScoresWithSameMods.BestScoreBasedByTotalScore);
             }
 
             await database.Scores.AddScore(score);

--- a/Sunrise.Server/appsettings.Development.json
+++ b/Sunrise.Server/appsettings.Development.json
@@ -15,7 +15,8 @@
       "CallsPerWindow": 200,
       "Window": 10,
       "QueueLimit": 20
-    }
+    },
+    "UseNewPerformanceCalculationAlgorithm": false
   },
   "BeatmapHype": {
     "UserHypesWeekly": 10,

--- a/Sunrise.Server/appsettings.Production.json.example
+++ b/Sunrise.Server/appsettings.Production.json.example
@@ -16,7 +16,8 @@
       "CallsPerWindow": 200,
       "Window": 10,
       "QueueLimit": 20
-    }
+    },
+    "UseNewPerformanceCalculationAlgorithm": false
   },
   "BeatmapHype": {
     "UserHypesWeekly": 10,

--- a/Sunrise.Server/appsettings.Tests.json
+++ b/Sunrise.Server/appsettings.Tests.json
@@ -26,7 +26,8 @@
       "CallsPerWindow": 100,
       "Window": 10,
       "QueueLimit": 0
-    }
+    },
+    "UseNewPerformanceCalculationAlgorithm": false
   },
   "BeatmapHype": {
     "UserHypesWeekly": 3,

--- a/Sunrise.Shared/Application/Configuration.cs
+++ b/Sunrise.Shared/Application/Configuration.cs
@@ -30,15 +30,7 @@ public static class Configuration
         }
     };
 
-    public static bool IsDevelopment => Env == "Development";
-    public static bool IsTestingEnv => Env == "Tests";
-
-    public static string WebTokenSecret
-    {
-        get { return _webTokenSecret ??= GetApiToken().ToHash(); }
-    }
-
-    public static TokenValidationParameters WebTokenValidationParameters = new TokenValidationParameters
+    public static TokenValidationParameters WebTokenValidationParameters = new()
     {
         ValidIssuer = "Sunrise",
         ValidAudience = "Sunrise",
@@ -49,6 +41,14 @@ public static class Configuration
         ValidateIssuerSigningKey = true,
         ClockSkew = TimeSpan.Zero
     };
+
+    public static bool IsDevelopment => Env == "Development";
+    public static bool IsTestingEnv => Env == "Tests";
+
+    public static string WebTokenSecret
+    {
+        get { return _webTokenSecret ??= GetApiToken().ToHash(); }
+    }
 
     public static TimeSpan WebTokenExpiration =>
         TimeSpan.FromSeconds(Config.GetSection("API").GetValue<int?>("TokenExpiresIn") ?? 3600);
@@ -78,13 +78,13 @@ public static class Configuration
 
     public static int GeneralCallsPerWindow =>
         Config.GetSection("General").GetSection("RateLimit").GetValue<int?>("CallsPerWindow") ?? 100;
-    
+
     public static int CountryChangeCooldownInDays =>
         Config.GetSection("General").GetValue<int?>("CountryChangeCooldownInDays") ?? 90;
-    
+
     public static int UsernameChangeCooldownInDays =>
         Config.GetSection("General").GetValue<int?>("UsernameChangeCooldownInDays") ?? 30;
-    
+
     public static int GeneralWindow =>
         Config.GetSection("General").GetSection("RateLimit").GetValue<int?>("Window") ?? 10;
 
@@ -101,16 +101,22 @@ public static class Configuration
         Config.GetSection("General").GetValue<bool?>("IgnoreBeatmapRanking") ?? false;
 
     public static bool UseCustomBackgrounds => Config.GetSection("General").GetValue<bool?>("UseCustomBackgrounds") ?? false;
-    
+
+
+    // - Will use best scores by performance points instead of total score for performance calculation
+    public static bool UseNewPerformanceCalculationAlgorithm =>
+        Config.GetSection("General").GetValue<bool?>("UseNewPerformanceCalculationAlgorithm") ?? false;
+
     // Beatmap hype
     public static int UserHypesWeekly =>
         Config.GetSection("BeatmapHype").GetValue<int?>("UserHypesWeekly") ?? 6;
-    
+
     public static int HypesToStartHypeTrain =>
         Config.GetSection("BeatmapHype").GetValue<int?>("HypesToStartHypeTrain") ?? 3;
+
     public static bool AllowMultipleHypeFromSameUser =>
         Config.GetSection("BeatmapHype").GetValue<bool?>("AllowMultipleHypeFromSameUser") ?? true;
-    
+
 
     // Moderation section
     public static int BannablePpThreshold => Config.GetSection("Moderation").GetSection("BannablePPThreshold").Get<int?>() ?? 3000;

--- a/Sunrise.Shared/Database/Extensions/ScoreQueryExtensions.cs
+++ b/Sunrise.Shared/Database/Extensions/ScoreQueryExtensions.cs
@@ -50,12 +50,12 @@ public static class ScoreQueryableExtensions
                 ).First());
     }
 
-    public static IQueryable<Score> SelectUsersPersonalBestScores(this IQueryable<Score> queryable)
+    public static IQueryable<Score> SelectUsersPersonalBestScores(this IQueryable<Score> queryable, bool rankByPerformancePoints = false)
     {
         var gameModesWithoutScoreMultiplier = GameModeExtensions.GetGameModesWithoutScoreMultiplier();
 
         return queryable
-            .Where(x => x.SubmissionStatus == SubmissionStatus.Best)
+            .Where(x => rankByPerformancePoints || x.SubmissionStatus == SubmissionStatus.Best) // Ignore submission status when ranking by pp
             .GroupBy(x => new
             {
                 x.UserId,
@@ -63,7 +63,7 @@ public static class ScoreQueryableExtensions
             })
             .Select(g =>
                 g.OrderByDescending(x =>
-                    EF.Constant(gameModesWithoutScoreMultiplier).Contains(x.GameMode) ? x.PerformancePoints : x.TotalScore
+                    rankByPerformancePoints == true || EF.Constant(gameModesWithoutScoreMultiplier).Contains(x.GameMode) ? x.PerformancePoints : x.TotalScore
                 ).First());
     }
 

--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -2,6 +2,7 @@ using CSharpFunctionalExtensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using osu.Shared;
+using Sunrise.Shared.Application;
 using Sunrise.Shared.Database.Extensions;
 using Sunrise.Shared.Database.Models;
 using Sunrise.Shared.Database.Models.Users;
@@ -54,7 +55,7 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
             .FilterValidScores()
             .FilterPassedRankedScores()
             .Where(x => x.GameMode == EF.Constant(mode))
-            .SelectUsersPersonalBestScores();
+            .SelectUsersPersonalBestScores(Configuration.UseNewPerformanceCalculationAlgorithm);
 
         var scoresQuery = dbContext.Scores
             .FromSqlRaw(groupedBestScores.ToQueryString())
@@ -131,7 +132,7 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
         {
             scoresGrouped = scoresGrouped.Where(s => s.Mods == EF.Constant(mods));
         }
-        
+
         if (type is LeaderboardType.GlobalIncludesMods && mods != null)
         {
             scoresGrouped = mods != Mods.None ? scoresGrouped.Where(s => (s.Mods & EF.Constant(mods)) == EF.Constant(mods)) : scoresGrouped.Where(s => s.Mods == EF.Constant(Mods.None));
@@ -177,7 +178,7 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
             case ScoreTableType.Best:
                 scoresQuery = scoresQuery
                     .FilterPassedRankedScores()
-                    .SelectUsersPersonalBestScores();
+                    .SelectUsersPersonalBestScores(Configuration.UseNewPerformanceCalculationAlgorithm);
                 break;
             case ScoreTableType.Top:
                 scoresQuery = scoresQuery

--- a/Sunrise.Shared/Objects/UserPersonalBestScores.cs
+++ b/Sunrise.Shared/Objects/UserPersonalBestScores.cs
@@ -1,0 +1,10 @@
+﻿using Sunrise.Shared.Application;
+using Sunrise.Shared.Database.Models;
+
+namespace Sunrise.Shared.Objects;
+
+public class UserPersonalBestScores(Score bestScoreBasedByTotalScore, Score? bestScoreBasedByPerformancePoints = null)
+{
+    public Score BestScoreBasedByTotalScore { get; } = bestScoreBasedByTotalScore;
+    public Score BestScoreForPerformanceCalculation { get; } = Configuration.UseNewPerformanceCalculationAlgorithm ? bestScoreBasedByPerformancePoints ?? throw new Exception("UserPersonalBestScores requires bestScoreBasedByPerformancePoints when Configuration.UseNewPerformanceCalculationAlgorithm is true.") : bestScoreBasedByTotalScore;
+}

--- a/Sunrise.Shared/Objects/UserPersonalBestScores.cs
+++ b/Sunrise.Shared/Objects/UserPersonalBestScores.cs
@@ -6,5 +6,5 @@ namespace Sunrise.Shared.Objects;
 public class UserPersonalBestScores(Score bestScoreBasedByTotalScore, Score? bestScoreBasedByPerformancePoints = null)
 {
     public Score BestScoreBasedByTotalScore { get; } = bestScoreBasedByTotalScore;
-    public Score BestScoreForPerformanceCalculation { get; } = Configuration.UseNewPerformanceCalculationAlgorithm ? bestScoreBasedByPerformancePoints ?? throw new Exception("UserPersonalBestScores requires bestScoreBasedByPerformancePoints when Configuration.UseNewPerformanceCalculationAlgorithm is true.") : bestScoreBasedByTotalScore;
+    public Score BestScoreForPerformanceCalculation { get; } = Configuration.UseNewPerformanceCalculationAlgorithm ? bestScoreBasedByPerformancePoints ?? bestScoreBasedByTotalScore : bestScoreBasedByTotalScore;
 }


### PR DESCRIPTION
We are implementing new performance calculation algorithm.

Based on it, new scores with better total score, but worse performance value, will not update performance points, and vice versa. 

For now, I'm going to have this feature under `General.UseNewPerformanceCalculationAlgorithm` flag in configuration. 
Please refer to compass guide (TODO: update with link) to enable this feature for your server. 

Closes: https://discord.com/channels/1328074330566955139/1393383629043925102

![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmV2NWw2Y2x1dHM2YW41OHFxYjJjaWRtM2g0aGR5ZnloZ3NrNG1uOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fLcCY4DU9OyE2YgPJy/giphy.gif)

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif -->