### PR TITLE
General multiplayer fixes

### DIFF
--- a/Sunrise.Server.Tests/Packets/PacketMultiMatchCreateTests.cs
+++ b/Sunrise.Server.Tests/Packets/PacketMultiMatchCreateTests.cs
@@ -1,0 +1,145 @@
+﻿using HOPEless.Bancho;
+using HOPEless.Bancho.Objects;
+using HOPEless.osu;
+using Microsoft.Extensions.DependencyInjection;
+using osu.Shared;
+using Sunrise.Shared.Repositories;
+using Sunrise.Shared.Repositories.Multiplayer;
+using Sunrise.Tests.Abstracts;
+using Sunrise.Tests.Utils;
+
+namespace Sunrise.Server.Tests.Packets;
+
+[Collection("Integration tests collection")]
+public class PacketMultiMatchCreateTests(IntegrationDatabaseFixture fixture) : BanchoTest(fixture)
+{
+    [Fact]
+    public async Task TestShouldCreateMultiMatch()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+
+        var user = await CreateTestUser();
+        var loginToken = await GetUserAuthOsuToken(client, user);
+        client.UseUserAuthOsuToken(loginToken);
+
+        var newMatch = new BanchoMultiplayerMatch
+        {
+            GameName = "Test Match",
+            MultiType = MultiTypes.Standard,
+            BeatmapName = "Test Beatmap",
+            BeatmapChecksum = "abc123",
+            BeatmapId = 0,
+            InProgress = false,
+            ActiveMods = Mods.HardRock | Mods.DoubleTime,
+            HostId = user.Id,
+            PlayMode = GameMode.Standard,
+            MultiWinCondition = MultiWinConditions.ScoreV2,
+            MultiTeamType = MultiTeamTypes.HeadToHead,
+            SpecialModes = MultiSpecialModes.None,
+            Seed = 0,
+            GamePassword = "testpassword"
+        };
+
+        PacketHelper.WritePacket(PacketType.ClientMultiMatchCreate, newMatch);
+        var requestBody = PacketHelper.GetBytesToSend();
+
+        // Act
+        var response = await client.PostAsync("/", new ByteArrayContent(requestBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var matchRepository = App.Services.GetRequiredService<MatchRepository>();
+
+        Assert.Contains(matchRepository.GetMatches(), x => x.Match.GameName == newMatch.GameName && x.Match.HostId == newMatch.HostId);
+    }
+
+    [Fact]
+    public async Task TestShouldCreateMultiMatchAndAddToUserSession()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+
+        var user = await CreateTestUser();
+        var loginToken = await GetUserAuthOsuToken(client, user);
+        client.UseUserAuthOsuToken(loginToken);
+
+        var newMatch = new BanchoMultiplayerMatch
+        {
+            GameName = "Test Match",
+            MultiType = MultiTypes.Standard,
+            BeatmapName = "Test Beatmap",
+            BeatmapChecksum = "abc123",
+            BeatmapId = 0,
+            InProgress = false,
+            ActiveMods = Mods.HardRock | Mods.DoubleTime,
+            HostId = user.Id,
+            PlayMode = GameMode.Standard,
+            MultiWinCondition = MultiWinConditions.ScoreV2,
+            MultiTeamType = MultiTeamTypes.HeadToHead,
+            SpecialModes = MultiSpecialModes.None,
+            Seed = 0,
+            GamePassword = "testpassword"
+        };
+
+        PacketHelper.WritePacket(PacketType.ClientMultiMatchCreate, newMatch);
+        var requestBody = PacketHelper.GetBytesToSend();
+
+        // Act
+        var response = await client.PostAsync("/", new ByteArrayContent(requestBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var sessionRepository = App.Services.GetRequiredService<SessionRepository>();
+
+        Assert.NotNull(sessionRepository.GetSession(userId: user.Id)?.Match);
+    }
+
+    [Fact]
+    public async Task TestShouldCreateMultiMatchOnceWithMultipleRequests()
+    {
+        // Arrange
+        var client = App.CreateClient().UseClient("c");
+
+        var user = await CreateTestUser();
+        var loginToken = await GetUserAuthOsuToken(client, user);
+        client.UseUserAuthOsuToken(loginToken);
+
+        var newMatch = new BanchoMultiplayerMatch
+        {
+            GameName = "Test Match",
+            MultiType = MultiTypes.Standard,
+            BeatmapName = "Test Beatmap",
+            BeatmapChecksum = "abc123",
+            BeatmapId = 0,
+            InProgress = false,
+            ActiveMods = Mods.HardRock | Mods.DoubleTime,
+            HostId = user.Id,
+            PlayMode = GameMode.Standard,
+            MultiWinCondition = MultiWinConditions.ScoreV2,
+            MultiTeamType = MultiTeamTypes.HeadToHead,
+            SpecialModes = MultiSpecialModes.None,
+            Seed = 0,
+            GamePassword = "testpassword"
+        };
+
+        for (var i = 0; i < 5; i++)
+        {
+            PacketHelper.WritePacket(PacketType.ClientMultiMatchCreate, newMatch);
+        }
+
+        var requestBody = PacketHelper.GetBytesToSend();
+
+        // Act
+        var response = await client.PostAsync("/", new ByteArrayContent(requestBody));
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+
+        var matchRepository = App.Services.GetRequiredService<MatchRepository>();
+
+        Assert.Single(matchRepository.GetMatches());
+    }
+}

--- a/Sunrise.Server/Commands/ChatCommands/Multiplayer/MultiSizeCommand.cs
+++ b/Sunrise.Server/Commands/ChatCommands/Multiplayer/MultiSizeCommand.cs
@@ -1,3 +1,4 @@
+using HOPEless.osu;
 using Sunrise.Server.Attributes;
 using Sunrise.Shared.Objects;
 using Sunrise.Shared.Objects.Sessions;
@@ -14,7 +15,7 @@ public class MultiSizeCommand : IChatCommand
             throw new InvalidOperationException("Multiplayer command was called without being in a multiplayer room.");
         }
 
-        if (session.Match.HasHostPrivileges(session) == false)
+        if (!session.Match.HasHostPrivileges(session))
         {
             session.SendChannelMessage(channel.Name, "This command can only be used by the host of the room.");
             return Task.CompletedTask;
@@ -26,7 +27,7 @@ public class MultiSizeCommand : IChatCommand
             return Task.CompletedTask;
         }
 
-        if (int.TryParse(args[0], out var size) == false)
+        if (!int.TryParse(args[0], out var size))
         {
             session.SendChannelMessage(channel.Name, "Invalid size.");
             return Task.CompletedTask;
@@ -35,6 +36,16 @@ public class MultiSizeCommand : IChatCommand
         if (size is < 1 or > 16)
         {
             session.SendChannelMessage(channel.Name, "Size must be between 1 and 16.");
+            return Task.CompletedTask;
+        }
+
+        var isPlayerSlotsAffected = session.Match.Slots.Where(x => x.Key >= size && x.Value.UserId != -1).Any();
+        var openSlots = session.Match.Slots.Count(x => x.Value.Status != MultiSlotStatus.Locked);
+
+        // TODO: We should handle this properly, but for some reason we don't
+        if (isPlayerSlotsAffected && size < openSlots)
+        {
+            session.SendChannelMessage(channel.Name, "You cannot resize the multiplayer room if there are players in slots that would be removed. Please kick the players in those slots first.");
             return Task.CompletedTask;
         }
 

--- a/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchCreateHandler.cs
+++ b/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchCreateHandler.cs
@@ -26,18 +26,7 @@ public class MultiMatchCreateHandler : IPacketHandler
 
         var multiplayerMatches = ServicesProviderHolder.GetRequiredService<MatchRepository>();
 
-        // NOTE: As the host can not join the lobby, best would be not to announce the creation, but I'll leave it for another day
-        multiplayerMatches.CreateMatch(match);
-
-        var isHostJoinedMatch = multiplayerMatches.TryJoinMatch(session,
-            new BanchoMultiplayerJoin
-            {
-                MatchId = match.MatchId,
-                Password = match.GamePassword
-            });
-
-        if (!isHostJoinedMatch)
-            multiplayerMatches.RemoveMatch(match.MatchId);
+        multiplayerMatches.CreateMatchWithHost(session, match);
 
         return Task.CompletedTask;
     }

--- a/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchCreateHandler.cs
+++ b/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchCreateHandler.cs
@@ -26,14 +26,18 @@ public class MultiMatchCreateHandler : IPacketHandler
 
         var multiplayerMatches = ServicesProviderHolder.GetRequiredService<MatchRepository>();
 
+        // NOTE: As the host can not join the lobby, best would be not to announce the creation, but I'll leave it for another day
         multiplayerMatches.CreateMatch(match);
 
-        multiplayerMatches.JoinMatch(session,
+        var isHostJoinedMatch = multiplayerMatches.TryJoinMatch(session,
             new BanchoMultiplayerJoin
             {
                 MatchId = match.MatchId,
                 Password = match.GamePassword
             });
+
+        if (!isHostJoinedMatch)
+            multiplayerMatches.RemoveMatch(match.MatchId);
 
         return Task.CompletedTask;
     }

--- a/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchJoinHandler.cs
+++ b/Sunrise.Server/Packets/PacketHandlers/Multiplayer/MultiMatchJoinHandler.cs
@@ -16,7 +16,8 @@ public class MultiMatchJoinHandler : IPacketHandler
 
         var multiplayerMatches = ServicesProviderHolder.GetRequiredService<MatchRepository>();
 
-        multiplayerMatches.JoinMatch(session, joinData);
+        // TryJoinMatch sends the SendMultiMatchJoinFail packet if the join fails, so we don't need to handle non-successful joins here
+        multiplayerMatches.TryJoinMatch(session, joinData);
 
         return Task.CompletedTask;
     }

--- a/Sunrise.Server/Program.cs
+++ b/Sunrise.Server/Program.cs
@@ -34,11 +34,12 @@ builder.Configure();
 
 var app = builder.Build();
 
-app.UseHangfireDashboard("/hangfire",
-    new DashboardOptions
-    {
-        Authorization = [new HangfireAuthorizationFilter()]
-    });
+// TODO: Authorisation doesn't work correctly, for security reasons I'm going to disable it completely for now. Thanks to vertexxdev for reporting this.
+// app.UseHangfireDashboard("/hangfire",
+//     new DashboardOptions
+//     {
+//         Authorization = [new HangfireAuthorizationFilter()]
+//     });
 
 app.Setup();
 app.UseHealthChecks("/health");

--- a/Sunrise.Shared/Objects/Multiplayer/MultiplayerMatch.cs
+++ b/Sunrise.Shared/Objects/Multiplayer/MultiplayerMatch.cs
@@ -13,6 +13,7 @@ namespace Sunrise.Shared.Objects.Multiplayer;
 public class MultiplayerMatch
 {
     private readonly int _roomCreatorId;
+    public readonly DateTime CreatedAt = DateTime.UtcNow;
 
     public MultiplayerMatch(MatchRepository matches, BanchoMultiplayerMatch newMatch)
     {

--- a/Sunrise.Shared/Objects/Multiplayer/MultiplayerMatch.cs
+++ b/Sunrise.Shared/Objects/Multiplayer/MultiplayerMatch.cs
@@ -93,12 +93,12 @@ public class MultiplayerMatch
         ApplyNewChanges();
     }
 
-    public void AddPlayer(Session session)
+    public bool TryAddPlayer(Session session)
     {
         if (session.Match != null || Players.ContainsKey(session.UserId))
         {
             session.SendMultiMatchJoinFail();
-            return;
+            return false;
         }
 
         var openSlot = GetSlot(MultiSlotStatus.Open);
@@ -106,10 +106,14 @@ public class MultiplayerMatch
         if (openSlot == null)
         {
             session.SendMultiMatchJoinFail();
-            return;
+            return false;
         }
 
-        Players.TryAdd(session.UserId, session);
+        if (!Players.TryAdd(session.UserId, session))
+        {
+            session.SendMultiMatchJoinFail();
+            return false;
+        }
 
         openSlot.AddPlayer(session.UserId);
 
@@ -119,6 +123,7 @@ public class MultiplayerMatch
         chatChannels.JoinChannel($"#multiplayer_{Match.MatchId}", session, true);
 
         ApplyNewChanges();
+        return true;
     }
 
     public void RemovePlayer(Session session, bool forced = false)

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Hangfire;
 using HOPEless.Bancho;
 using HOPEless.Bancho.Objects;
 using Sunrise.Shared.Objects.Multiplayer;
@@ -15,6 +16,11 @@ public class MatchRepository
     private readonly ConcurrentDictionary<int, Session> _sessionsInLobby = new();
 
     private int _matchIdCounter;
+
+    public MatchRepository(IRecurringJobManager recurringJobManager)
+    {
+        recurringJobManager.AddOrUpdate("ClearInactiveMatches", () => ClearInactiveMatches(), Cron.Minutely);
+    }
 
     public IEnumerable<MultiplayerMatch> GetMatches()
     {
@@ -122,5 +128,12 @@ public class MatchRepository
         }
 
         return Interlocked.Increment(ref _matchIdCounter);
+    }
+
+    public void ClearInactiveMatches()
+    {
+        _matches.Where(x => x.Value.CreatedAt < DateTime.UtcNow - TimeSpan.FromMinutes(1) && x.Value.Players.IsEmpty)
+            .ToList()
+            .ForEach(x => RemoveMatch(x.Key));
     }
 }

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -81,7 +81,7 @@ public class MatchRepository
 
         if (!multiplayerMatch.TryAddPlayer(session))
         {
-            // TryJoinMatch sends the SendMultiMatchJoinFail packet if the join fails, so we don't need to handle non-successful joins here
+            // TryAddPlayer sends the SendMultiMatchJoinFail packet if the join fails, so we don't need to handle non-successful joins here
             return false;
         }
 

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -8,9 +8,18 @@ namespace Sunrise.Shared.Repositories.Multiplayer;
 
 public class MatchRepository
 {
+    private readonly ConcurrentQueue<(int id, DateTime time)> _freeMatchIds = new();
     private readonly ConcurrentDictionary<int, MultiplayerMatch> _matches = new();
+    private readonly TimeSpan _reuseMatchIdDelay = TimeSpan.FromSeconds(10);
+
     private readonly ConcurrentDictionary<int, Session> _sessionsInLobby = new();
-    private short _matchIdCounter = 1;
+
+    private int _matchIdCounter;
+
+    public IEnumerable<MultiplayerMatch> GetMatches()
+    {
+        return _matches.Values;
+    }
 
     public void JoinLobby(Session session)
     {
@@ -33,7 +42,7 @@ public class MatchRepository
         {
             Match =
             {
-                MatchId = _matchIdCounter++
+                MatchId = GetNextMatchId()
             }
         };
 
@@ -72,10 +81,11 @@ public class MatchRepository
         multiplayerMatch.UpdateMatchSettings(match, session);
     }
 
-    public void RemoveMatch(int matchId)
+    public void RemoveMatch(int matchId, bool discardReuseMatchIdDelay = false)
     {
         _matches.TryRemove(matchId, out _);
         WriteRemoveToLobby(matchId);
+        _freeMatchIds.Enqueue((matchId, discardReuseMatchIdDelay ? DateTime.MinValue : DateTime.UtcNow));
     }
 
     public void WriteUpdateToLobby(MultiplayerMatch match, bool isNewLobby = false)
@@ -97,5 +107,20 @@ public class MatchRepository
     public int GetMatchCount()
     {
         return _matches.Count;
+    }
+
+    private int GetNextMatchId()
+    {
+        while (_freeMatchIds.TryPeek(out var entry))
+        {
+            // If user will send request to join match X, which is deleted in the middle of the request and replaced with match Y. X.MatchId shouldn't be == to Y.MatchId
+            if (DateTime.UtcNow - entry.time < _reuseMatchIdDelay)
+                break;
+
+            if (_freeMatchIds.TryDequeue(out entry))
+                return entry.id;
+        }
+
+        return Interlocked.Increment(ref _matchIdCounter);
     }
 }

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -41,21 +41,27 @@ public class MatchRepository
         WriteUpdateToLobby(multiplayerMatch, true);
     }
 
-    public void JoinMatch(Session session, BanchoMultiplayerJoin joinData)
+    public bool TryJoinMatch(Session session, BanchoMultiplayerJoin joinData)
     {
         if (!_matches.TryGetValue(joinData.MatchId, out var multiplayerMatch))
         {
             session.SendMultiMatchJoinFail();
-            return;
+            return false;
         }
 
         if (multiplayerMatch.Match.GamePassword != null && multiplayerMatch.Match.GamePassword != joinData.Password.Replace(" ", "_"))
         {
             session.SendMultiMatchJoinFail();
-            return;
+            return false;
         }
 
-        multiplayerMatch.AddPlayer(session);
+        if (!multiplayerMatch.TryAddPlayer(session))
+        {
+            session.SendMultiMatchJoinFail();
+            return false;
+        }
+
+        return true;
     }
 
     public void UpdateMatch(Session session, BanchoMultiplayerMatch match)

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -42,7 +42,7 @@ public class MatchRepository
         _sessionsInLobby.TryRemove(session.UserId, out _);
     }
 
-    public void CreateMatch(BanchoMultiplayerMatch match)
+    public bool CreateMatchWithHost(Session session, BanchoMultiplayerMatch match)
     {
         var multiplayerMatch = new MultiplayerMatch(this, match)
         {
@@ -53,7 +53,16 @@ public class MatchRepository
         };
 
         _matches.TryAdd(match.MatchId, multiplayerMatch);
+
+        if (!multiplayerMatch.TryAddPlayer(session))
+        {
+            _matches.TryRemove(match.MatchId, out _);
+            _freeMatchIds.Enqueue((match.MatchId, DateTime.MinValue)); // We didn't announce this match to lobby, so we can reuse this match id immediately
+            return false;
+        }
+
         WriteUpdateToLobby(multiplayerMatch, true);
+        return true;
     }
 
     public bool TryJoinMatch(Session session, BanchoMultiplayerJoin joinData)

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -72,7 +72,7 @@ public class MatchRepository
 
         if (!multiplayerMatch.TryAddPlayer(session))
         {
-            session.SendMultiMatchJoinFail();
+            // TryJoinMatch sends the SendMultiMatchJoinFail packet if the join fails, so we don't need to handle non-successful joins here
             return false;
         }
 
@@ -95,7 +95,7 @@ public class MatchRepository
         if (match.Match.InProgress)
             match.EndGame(true);
 
-        foreach (var session in _sessionsInLobby.Values)
+        foreach (var session in match.Players.Values)
         {
             match.RemovePlayer(session, true);
         }

--- a/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
+++ b/Sunrise.Shared/Repositories/Multiplayer/MatchRepository.cs
@@ -89,6 +89,17 @@ public class MatchRepository
 
     public void RemoveMatch(int matchId, bool discardReuseMatchIdDelay = false)
     {
+        if (!_matches.TryGetValue(matchId, out var match))
+            return;
+
+        if (match.Match.InProgress)
+            match.EndGame(true);
+
+        foreach (var session in _sessionsInLobby.Values)
+        {
+            match.RemovePlayer(session, true);
+        }
+
         _matches.TryRemove(matchId, out _);
         WriteRemoveToLobby(matchId);
         _freeMatchIds.Enqueue((matchId, discardReuseMatchIdDelay ? DateTime.MinValue : DateTime.UtcNow));

--- a/Sunrise.Shared/Repositories/SessionRepository.cs
+++ b/Sunrise.Shared/Repositories/SessionRepository.cs
@@ -22,11 +22,11 @@ public class SessionRepository
     private readonly ChatChannelRepository _channels;
     private readonly ConcurrentDictionary<string, Session> _sessions = new();
 
-    public SessionRepository(ChatChannelRepository channels)
+    public SessionRepository(ChatChannelRepository channels, IRecurringJobManager recurringJobManager)
     {
         _channels = channels;
 
-        RecurringJob.AddOrUpdate("ClearInactiveSessions", () => ClearInactiveSessions(), "*/1 * * * *");
+        recurringJobManager.AddOrUpdate("ClearInactiveSessions", () => ClearInactiveSessions(), "*/1 * * * *");
     }
 
     public void WriteToAllSessions(PacketType type, object data, int ignoreUserId = -1)

--- a/Sunrise.Tests/IntegrationDatabaseFixture.cs
+++ b/Sunrise.Tests/IntegrationDatabaseFixture.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Sunrise.Shared.Database;
 using Sunrise.Shared.Repositories;
+using Sunrise.Shared.Repositories.Multiplayer;
 using Sunrise.Tests.Manager;
 using Sunrise.Tests.Utils;
 
@@ -131,6 +132,7 @@ public class IntegrationDatabaseFixture : IAsyncLifetime
     {
         var sessions = scope.ServiceProvider.GetRequiredService<SessionRepository>();
         var channels = scope.ServiceProvider.GetRequiredService<ChatChannelRepository>();
+        var matches = scope.ServiceProvider.GetRequiredService<MatchRepository>();
         
         var existingSessions = sessions.GetSessions().ToList();
         await Task.WhenAll(
@@ -140,6 +142,12 @@ public class IntegrationDatabaseFixture : IAsyncLifetime
         Parallel.ForEach(existingChannels, channel =>
         {
             channels.RemoveAbstractChannel(channel.Name);
+        });
+        
+        var existingMatches = matches.GetMatches().ToList();
+        Parallel.ForEach(existingMatches, match =>
+        {
+            matches.RemoveMatch(match.Match.MatchId, true);
         });
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR addresses multiple multiplayer matches problems.

Fixes:
- **Disable hangfire dashboard due to security concerns** (Thanks to vertexxdev for informing me about the problem)
- If after match creation the host is already in the different match while trying to create a new one, instead of silently failing we disband the newly created lobby.
- We now reuse match Ids (previously it would overflow the short value)
- Possible issue with resize command was patched. 
- Adds cleanup cron for all possibly inactive matches.
- New tests were added.

<!--- Describe your changes in detail -->

<!--- Don't forget to add some funny or just cool image/gif, ex: ![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmV2NWw2Y2x1dHM2YW41OHFxYjJjaWRtM2g0aGR5ZnloZ3NrNG1uOSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fLcCY4DU9OyE2YgPJy/giphy.gif) -->
