### PR TITLE
Migrate to pomelo MySQL provider

### DIFF
--- a/Sunrise.API/Controllers/BeatmapController.cs
+++ b/Sunrise.API/Controllers/BeatmapController.cs
@@ -207,7 +207,7 @@ public class BeatmapController(DatabaseService database, BeatmapService beatmapS
 
         var (beatmapSetIdsWithHypeCount, totalCount) = await database.Beatmaps.Hypes.GetHypedBeatmaps(new QueryOptions(true, new Pagination(page, limit)), ct);
 
-        var result = beatmapSetIdsWithHypeCount.Select(async g =>
+        var resultTasks = beatmapSetIdsWithHypeCount.Select(async g =>
         {
             var (beatmapSetId, hypeCount) = g;
 
@@ -216,7 +216,9 @@ public class BeatmapController(DatabaseService database, BeatmapService beatmapS
                 return null;
 
             return new HypedBeatmapSetResponse(sessions, beatmapSetResult.Value, hypeCount);
-        }).Select(task => task.Result).Where(x => x != null).Select(x => x!).ToList();
+        });
+
+        var result = (await Task.WhenAll(resultTasks)).Where(x => x != null).Select(x => x!).ToList();
 
         return Ok(new HypedBeatmapSetsResponse(result, totalCount));
     }

--- a/Sunrise.API/Controllers/UserController.cs
+++ b/Sunrise.API/Controllers/UserController.cs
@@ -408,7 +408,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
 
         var (beatmapsIds, totalIdsCount) = await database.Scores.GetUserMostPlayedBeatmapIds(id, mode, new QueryOptions(true, new Pagination(page, limit)), ct);
 
-        var parsedBeatmaps = beatmapsIds.Select(async pair =>
+        var parsedBeatmapsTasks = beatmapsIds.Select(async pair =>
         {
             var bId = pair.Key;
             var count = pair.Value;
@@ -419,10 +419,12 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
 
             var beatmapSet = beatmapSetResult.Value;
 
-            var beatmap = beatmapSet?.Beatmaps.FirstOrDefault(b => b.Id == bId);
+            var beatmap = beatmapSet?.Beatmaps?.FirstOrDefault(b => b.Id == bId);
 
             return beatmap == null ? null : new MostPlayedBeatmapResponse(sessions, beatmap, count, beatmapSet);
-        }).Select(task => task.Result).Where(x => x != null).Select(x => x!).ToList();
+        });
+
+        var parsedBeatmaps = (await Task.WhenAll(parsedBeatmapsTasks)).Where(x => x != null).Select(x => x!).ToList();
 
         return Ok(new MostPlayedResponse(parsedBeatmaps, totalIdsCount));
     }
@@ -451,7 +453,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
 
         var (favourites, favouritesCount) = await database.Users.Favourites.GetUserFavouriteBeatmapIds(id, new QueryOptions(true, new Pagination(page, limit)), ct);
 
-        var parsedFavourites = favourites.Select(async setId =>
+        var parsedFavouritesTasks = favourites.Select(async setId =>
         {
             var beatmapSetResult = await beatmapService.GetBeatmapSet(session, setId, ct: ct);
             if (beatmapSetResult.IsFailure)
@@ -460,7 +462,9 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
             var beatmapSet = beatmapSetResult.Value;
 
             return beatmapSet == null ? null : new BeatmapSetResponse(sessions, beatmapSet);
-        }).Select(task => task.Result).Where(x => x != null).Select(x => x!).ToList();
+        });
+
+        var parsedFavourites = (await Task.WhenAll(parsedFavouritesTasks)).Where(x => x != null).Select(x => x!).ToList();
 
         return Ok(new BeatmapSetsResponse(parsedFavourites, favouritesCount));
     }
@@ -912,7 +916,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
 
         var ip = RegionService.GetUserIpAddress(Request);
 
-        if (Request.HasFormContentType == false)
+        if (!Request.HasFormContentType)
             return Problem(title: ApiErrorResponse.Title.UnableToChangeAvatar, detail: ApiErrorResponse.Detail.InvalidContentType, statusCode: StatusCodes.Status400BadRequest);
 
         if (Request.Form.Files.Count == 0)
@@ -931,7 +935,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
         var user = HttpContext.GetCurrentUserOrThrow();
         var ip = RegionService.GetUserIpAddress(Request);
 
-        if (Request.HasFormContentType == false)
+        if (!Request.HasFormContentType)
             return Problem(title: ApiErrorResponse.Title.UnableToChangeAvatar, detail: ApiErrorResponse.Detail.InvalidContentType, statusCode: StatusCodes.Status400BadRequest);
 
         if (Request.Form.Files.Count == 0)
@@ -955,7 +959,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
 
         var ip = RegionService.GetUserIpAddress(Request);
 
-        if (Request.HasFormContentType == false)
+        if (!Request.HasFormContentType)
             return Problem(title: ApiErrorResponse.Title.UnableToChangeBanner, detail: ApiErrorResponse.Detail.InvalidContentType, statusCode: StatusCodes.Status400BadRequest);
 
         if (Request.Form.Files.Count == 0)
@@ -974,7 +978,7 @@ public class UserController(BeatmapService beatmapService, DatabaseService datab
         var user = HttpContext.GetCurrentUserOrThrow();
         var ip = RegionService.GetUserIpAddress(Request);
 
-        if (Request.HasFormContentType == false)
+        if (!Request.HasFormContentType)
             return Problem(title: ApiErrorResponse.Title.UnableToChangeBanner, detail: ApiErrorResponse.Detail.InvalidContentType, statusCode: StatusCodes.Status400BadRequest);
 
         if (Request.Form.Files.Count == 0)

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Security.Authentication;
 using System.Transactions;
 using EFCoreSecondLevelCacheInterceptor;
+using EntityFrameworkCore.Locking.MySql;
 using Hangfire;
 using Hangfire.MySql;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -348,6 +349,9 @@ public static class Bootstrap
 
             optionsBuilder
                 .AddInterceptors(new SlowQueryLoggerInterceptor());
+
+            optionsBuilder
+                .UseLocking();
 
             optionsBuilder
                 .UseMySql(Configuration.DatabaseConnectionString, ServerVersion.AutoDetect(Configuration.DatabaseConnectionString));

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -525,7 +525,7 @@ public static class Bootstrap
         };
     }
 
-    public static void ApplyDatabaseBootstrapping(this WebApplication app)
+    public static async Task ApplyDatabaseBootstrapping(this WebApplication app)
     {
         using var scope = app.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
@@ -533,7 +533,7 @@ public static class Bootstrap
         if (!Configuration.IsTestingEnv)
             database.DbContext.Database.Migrate();
 
-        DatabaseSeeder.UseAsyncSeeding(database.DbContext).Wait();
+        await DatabaseSeeder.UseAsyncSeeding(database.DbContext);
     }
 
     public static void UseStaticBackgrounds(this WebApplication app)
@@ -607,7 +607,7 @@ public static class Bootstrap
         Configuration.Initialize();
     }
 
-    private class LazilyResolved<T> : Lazy<T>
+    private class LazilyResolved<T> : Lazy<T> where T : notnull
     {
         public LazilyResolved(IServiceProvider serviceProvider)
             : base(serviceProvider.GetRequiredService<T>)

--- a/Sunrise.Server/Bootstrap.cs
+++ b/Sunrise.Server/Bootstrap.cs
@@ -350,7 +350,7 @@ public static class Bootstrap
                 .AddInterceptors(new SlowQueryLoggerInterceptor());
 
             optionsBuilder
-                .UseMySQL(Configuration.DatabaseConnectionString);
+                .UseMySql(Configuration.DatabaseConnectionString, ServerVersion.AutoDetect(Configuration.DatabaseConnectionString));
         });
     }
 

--- a/Sunrise.Server/Commands/ChatCommands/HelpCommand.cs
+++ b/Sunrise.Server/Commands/ChatCommands/HelpCommand.cs
@@ -9,13 +9,11 @@ namespace Sunrise.Server.Commands.ChatCommands;
 [ChatCommand("help")]
 public class HelpCommand : IChatCommand
 {
-    public Task Handle(Session session, ChatChannel? channel, string[]? args)
+    public async Task Handle(Session session, ChatChannel? channel, string[]? args)
     {
         var message = $"Available commands: {Configuration.BotPrefix}" + string.Join($", {Configuration.BotPrefix}",
-            ChatCommandRepository.GetAvailableCommands(session));
+            await ChatCommandRepository.GetAvailableCommands(session));
 
         ChatCommandRepository.SendMessage(session, message);
-
-        return Task.CompletedTask;
     }
 }

--- a/Sunrise.Server/Controllers/ScoreController.cs
+++ b/Sunrise.Server/Controllers/ScoreController.cs
@@ -37,10 +37,11 @@ public class ScoreController(ScoreService scoreService, AssetBanchoService asset
         var clientHash = ServerParsers.ParseRijndaelString(osuVersion, iv, clientHashEncoded);
         var username = scoreSerialized.Split(':')[1].Trim();
 
-        if (!sessions.TryGetSession(username, passhash, out var session) || session == null)
+        var session = await sessions.TryGetSessionAsync(username, passhash);
+
+        if (session == null)
         {
             Log.Error("Failed to authenticate score submission for user {Username}. Invalid session.", username);
-
             return Ok("error: pass");
         }
 
@@ -75,7 +76,8 @@ public class ScoreController(ScoreService scoreService, AssetBanchoService asset
         if (fromEditor == "1" || leaderboardVersion != "4")
             return Ok("error: pass");
 
-        if (!sessions.TryGetSession(username, passhash, out var session) || session == null)
+        var session = await sessions.TryGetSessionAsync(username, passhash);
+        if (session == null)
             return Ok("error: pass");
 
         var result =
@@ -86,9 +88,15 @@ public class ScoreController(ScoreService scoreService, AssetBanchoService asset
 
     [HttpGet(RequestType.OsuGetReplay)]
     public async Task<IActionResult> GetReplay(
+        [FromQuery(Name = "u")] string username,
+        [FromQuery(Name = "h")] string passhash,
         [FromQuery(Name = "c")] int scoreId, CancellationToken ct = default
     )
     {
+        var session = await sessions.TryGetSessionAsync(username, passhash);
+        if (session == null)
+            return Ok("error: pass");
+
         var getReplayResult = await assetBanchoService.GetOsuReplayBytes(scoreId, ct);
         if (getReplayResult.IsFailure)
             return Ok("error: no-replay");

--- a/Sunrise.Server/Middlewares/Middleware.cs
+++ b/Sunrise.Server/Middlewares/Middleware.cs
@@ -169,7 +169,7 @@ public sealed class Middleware(
 
                 if (user.AccountStatus == UserAccountStatus.Disabled)
                 {
-                    database.Users.Moderation.EnableUser(user.Id).Wait();
+                    await database.Users.Moderation.EnableUser(user.Id);
                     // TODO: Send message from bot about account being enabled
                 }
             }

--- a/Sunrise.Server/Program.cs
+++ b/Sunrise.Server/Program.cs
@@ -46,7 +46,7 @@ app.Setup();
 app.UseHealthChecks("/health");
 app.UseScalarApiReference();
 
-app.ApplyDatabaseBootstrapping();
+await app.ApplyDatabaseBootstrapping();
 app.UseStaticBackgrounds();
 
 app.UseExceptionHandler();
@@ -63,14 +63,14 @@ if (Configuration.ClearCacheOnStartup)
 {
     using var scope = app.Services.CreateScope();
     var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
-    database.FlushAndUpdateRedisCache(false).Wait();
+    await database.FlushAndUpdateRedisCache(false);
 }
 
 var sessions = app.Services.GetRequiredService<SessionRepository>();
-sessions.AddBotToSession().Wait();
-RecurringJobs.RefreshServerBotAccount(CancellationToken.None).Wait();
+await sessions.AddBotToSession();
+await RecurringJobs.RefreshServerBotAccount(CancellationToken.None);
 
-app.Run();
+await app.RunAsync();
 
 namespace Sunrise.Server
 {

--- a/Sunrise.Server/Repositories/ChatCommandRepository.cs
+++ b/Sunrise.Server/Repositories/ChatCommandRepository.cs
@@ -52,7 +52,7 @@ public static class ChatCommandRepository
                 return;
             case null:
             {
-                var possibleCommands = GetAvailableCommands(session)
+                var possibleCommands = (await GetAvailableCommands(session))
                     .Where(x => x.Contains(command))
                     .ToArray();
 
@@ -94,12 +94,12 @@ public static class ChatCommandRepository
         await handler.Handle(session, channel, args);
     }
 
-    public static string[] GetAvailableCommands(Session session)
+    public static async Task<string[]> GetAvailableCommands(Session session)
     {
         using var scope = ServicesProviderHolder.CreateScope();
         var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
 
-        var sessionUser = database.Users.GetUser(session.UserId).Result;
+        var sessionUser = await database.Users.GetUser(session.UserId);
         if (sessionUser == null)
             return [];
 

--- a/Sunrise.Shared/Application/RecurringJobs.cs
+++ b/Sunrise.Shared/Application/RecurringJobs.cs
@@ -308,7 +308,7 @@ public class RecurringJobs
             ct);
 
         if (await Task.WhenAny(backupDatabaseTask, Task.Delay(60_000, ct)) == backupDatabaseTask)
-            return backupDatabaseTask.Result;
+            return await backupDatabaseTask;
 
         return Result.Failure<string>("Database backup operation timed out");
     }

--- a/Sunrise.Shared/Application/SunriseMetrics.cs
+++ b/Sunrise.Shared/Application/SunriseMetrics.cs
@@ -183,7 +183,17 @@ public class SunriseMetrics
 
     public SunriseMetrics()
     {
-        _ = RefreshDatabaseMetricsAsync();
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RefreshDatabaseMetricsAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Failed to refresh database metrics during startup.");
+            }
+        });
 
         RecurringJob.AddOrUpdate("Fetch database metrics", () => RefreshDatabaseMetricsAsync(), "*/1 * * * *");
     }

--- a/Sunrise.Shared/Database/Migrations/20250327193326_MigrateToMySQL.cs
+++ b/Sunrise.Shared/Database/Migrations/20250327193326_MigrateToMySQL.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
 
 #nullable disable
 
@@ -13,14 +13,14 @@ namespace Sunrise.Shared.Database.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterDatabase()
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "medal_file",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     Path = table.Column<string>(type: "longtext", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
                 },
@@ -28,14 +28,14 @@ namespace Sunrise.Shared.Database.Migrations
                 {
                     table.PrimaryKey("PK_medal_file", x => x.Id);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     Username = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8mb4_unicode_ci"),
                     Email = table.Column<string>(type: "varchar(255)", nullable: false, collation: "utf8mb4_unicode_ci"),
                     Passhash = table.Column<string>(type: "longtext", nullable: false),
@@ -52,14 +52,14 @@ namespace Sunrise.Shared.Database.Migrations
                 {
                     table.PrimaryKey("PK_user", x => x.Id);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "medal",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     Name = table.Column<string>(type: "longtext", nullable: false),
                     Description = table.Column<string>(type: "longtext", nullable: false),
                     GameMode = table.Column<byte>(type: "tinyint unsigned", nullable: true),
@@ -77,14 +77,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalTable: "medal_file",
                         principalColumn: "Id");
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "event_user",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     EventType = table.Column<int>(type: "int", nullable: false),
                     Ip = table.Column<string>(type: "varchar(255)", nullable: false),
@@ -101,14 +101,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "restriction",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     ExecutorId = table.Column<int>(type: "int", nullable: true),
                     Reason = table.Column<string>(type: "longtext", nullable: false),
@@ -130,14 +130,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_favourite_beatmap",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     BeatmapSetId = table.Column<int>(type: "int", nullable: false),
                     DateAdded = table.Column<DateTime>(type: "datetime(6)", nullable: false)
@@ -152,14 +152,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_file",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     OwnerId = table.Column<int>(type: "int", nullable: false),
                     Path = table.Column<string>(type: "longtext", nullable: false),
                     Type = table.Column<int>(type: "int", nullable: false),
@@ -176,14 +176,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_medals",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     MedalId = table.Column<int>(type: "int", nullable: false),
                     UnlockedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
@@ -198,14 +198,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_stats",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     GameMode = table.Column<byte>(type: "tinyint unsigned", nullable: false),
                     Accuracy = table.Column<double>(type: "double", nullable: false),
@@ -231,14 +231,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_stats_snapshot",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     GameMode = table.Column<byte>(type: "tinyint unsigned", nullable: false),
                     SnapshotsJson = table.Column<string>(type: "longtext", nullable: false)
@@ -253,14 +253,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "score",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     BeatmapId = table.Column<int>(type: "int", nullable: false),
                     ScoreHash = table.Column<string>(type: "longtext", nullable: false),
@@ -303,7 +303,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalTable: "user_file",
                         principalColumn: "Id");
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_event_user_EventType_UserId",

--- a/Sunrise.Shared/Database/Migrations/20250330181953_AddUserGrades.cs
+++ b/Sunrise.Shared/Database/Migrations/20250330181953_AddUserGrades.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -16,7 +16,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     GameMode = table.Column<byte>(type: "tinyint unsigned", nullable: false),
                     CountXH = table.Column<int>(type: "int", nullable: false),
@@ -38,7 +38,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_user_grades_UserId_GameMode",

--- a/Sunrise.Shared/Database/Migrations/20250403173344_AddCustomBeatmapStatuses.cs
+++ b/Sunrise.Shared/Database/Migrations/20250403173344_AddCustomBeatmapStatuses.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -16,7 +16,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     BeatmapSetId = table.Column<int>(type: "int", nullable: false),
                     BeatmapHash = table.Column<string>(type: "longtext", nullable: false),
                     UpdatedByUserId = table.Column<int>(type: "int", nullable: false),
@@ -32,7 +32,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_custom_beatmap_status_UpdatedByUserId",

--- a/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.cs
+++ b/Sunrise.Shared/Database/Migrations/20250508213243_AddUserMetadataTable.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -16,7 +16,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     Playstyle = table.Column<int>(type: "int", nullable: false),
                     Location = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
@@ -38,7 +38,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_user_metadata_UserId",

--- a/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.cs
+++ b/Sunrise.Shared/Database/Migrations/20250509040239_AddUserRelationshipTable.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -16,7 +16,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     TargetId = table.Column<int>(type: "int", nullable: false),
                     Relation = table.Column<int>(type: "int", nullable: false)
@@ -37,7 +37,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_user_relationship_TargetId",

--- a/Sunrise.Shared/Database/Migrations/20250512014617_AddUserInventoryItemAndBeatmapHypes.cs
+++ b/Sunrise.Shared/Database/Migrations/20250512014617_AddUserInventoryItemAndBeatmapHypes.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -16,7 +16,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     BeatmapSetId = table.Column<int>(type: "int", nullable: false),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     Hypes = table.Column<int>(type: "int", nullable: false)
@@ -31,14 +31,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "user_inventory_item",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     ItemType = table.Column<int>(type: "int", nullable: false),
                     Quantity = table.Column<int>(type: "int", nullable: false)
@@ -53,7 +53,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_beatmap_hype_BeatmapSetId_Hypes",

--- a/Sunrise.Shared/Database/Migrations/20250520134458_AddBeatmapEvents.cs
+++ b/Sunrise.Shared/Database/Migrations/20250520134458_AddBeatmapEvents.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
 
 #nullable disable
 
@@ -17,7 +17,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     BeatmapSetId = table.Column<int>(type: "int", nullable: false),
                     ExecutorId = table.Column<int>(type: "int", nullable: false),
                     EventType = table.Column<int>(type: "int", nullable: false),
@@ -34,7 +34,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateIndex(
                 name: "IX_event_beatmap_BeatmapSetId",

--- a/Sunrise.Shared/Database/Migrations/20260419233843_AddScoreSubmissionRequestAndProcessingTask.cs
+++ b/Sunrise.Shared/Database/Migrations/20260419233843_AddScoreSubmissionRequestAndProcessingTask.cs
@@ -1,6 +1,6 @@
 using System;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
-using MySql.EntityFrameworkCore.Metadata;
 
 #nullable disable
 
@@ -25,7 +25,7 @@ namespace Sunrise.Shared.Database.Migrations
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     UserId = table.Column<int>(type: "int", nullable: false),
                     ScoreHash = table.Column<string>(type: "varchar(255)", nullable: false),
                     ScoreSerialized = table.Column<string>(type: "longtext", nullable: false),
@@ -53,14 +53,14 @@ namespace Sunrise.Shared.Database.Migrations
                         principalTable: "user_file",
                         principalColumn: "Id");
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "score_processing_task",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
-                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     TaskType = table.Column<int>(type: "int", nullable: false),
                     ScoreSubmissionRequestId = table.Column<int>(type: "int", nullable: true),
                     ScoreId = table.Column<int>(type: "int", nullable: true),
@@ -91,7 +91,7 @@ namespace Sunrise.Shared.Database.Migrations
                         principalTable: "score_submission_request",
                         principalColumn: "Id");
                 })
-                .Annotation("MySQL:Charset", "utf8mb4");
+                .Annotation("MySql:CharSet", "utf8mb4");
             
             migrationBuilder.CreateIndex(
                 name: "IX_score_ScoreHash_Status_Id",

--- a/Sunrise.Shared/Database/Migrations/20260608225230_AddPomeloIdentityColumn.Designer.cs
+++ b/Sunrise.Shared/Database/Migrations/20260608225230_AddPomeloIdentityColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Sunrise.Shared.Database;
 
@@ -11,9 +12,11 @@ using Sunrise.Shared.Database;
 namespace Sunrise.Shared.Database.Migrations
 {
     [DbContext(typeof(SunriseDbContext))]
-    partial class SunriseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608225230_AddPomeloIdentityColumn")]
+    partial class AddPomeloIdentityColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Sunrise.Shared/Database/Migrations/20260608225230_AddPomeloIdentityColumn.cs
+++ b/Sunrise.Shared/Database/Migrations/20260608225230_AddPomeloIdentityColumn.cs
@@ -1,0 +1,379 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Sunrise.Shared.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPomeloIdentityColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_stats_snapshot",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_stats",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_relationship",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_metadata",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_medals",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_inventory_item",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_grades",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_file",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_favourite_beatmap",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score_submission_request",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score_processing_task",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "restriction",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "medal_file",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "medal",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "event_user",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "event_beatmap",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "custom_beatmap_status",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "beatmap_hype",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_stats_snapshot",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_stats",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_relationship",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_metadata",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_medals",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_inventory_item",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_grades",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_file",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user_favourite_beatmap",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "user",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score_submission_request",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score_processing_task",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "score",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "restriction",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "medal_file",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "medal",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "event_user",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "event_beatmap",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "custom_beatmap_status",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Id",
+                table: "beatmap_hype",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int")
+                .OldAnnotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn);
+        }
+    }
+}

--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using CSharpFunctionalExtensions;
+using EntityFrameworkCore.Locking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using osu.Shared;
@@ -14,7 +16,6 @@ using Sunrise.Shared.Extensions.Beatmaps;
 using Sunrise.Shared.Extensions.Scores;
 using Sunrise.Shared.Objects;
 using Sunrise.Shared.Utils;
-using SubmissionStatus = Sunrise.Shared.Enums.Scores.SubmissionStatus;
 using GameMode = Sunrise.Shared.Enums.Beatmaps.GameMode;
 
 namespace Sunrise.Shared.Database.Repositories;
@@ -259,7 +260,7 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
         var scoresIds = string.Join(",", scores.Select(s => s.Id));
 
         var connection = dbContext.Database.GetDbConnection();
-        if (connection.State != System.Data.ConnectionState.Open)
+        if (connection.State != ConnectionState.Open)
             await connection.OpenAsync(ct);
 
         var gameModesWithoutScoreMultiplier = GameModeExtensions.GetGameModesWithoutScoreMultiplier();
@@ -326,23 +327,12 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
     {
         var excludeId = excludeScoreId ?? 0;
 
-        // TODO: Use EntityFrameworkCore.Locking.MySql instead after move to Pomelo MySQL provider
-        // TODO: Use FilterPassedScoreableScores to filter scoreable scores
         var scores = await dbContext.Scores
-            .FromSqlInterpolated($"""
-                                  SELECT * FROM score
-                                  WHERE UserId = {userId}
-                                    AND BeatmapHash = {beatmapHash}
-                                    AND GameMode = {(int)gameMode}
-                                    AND IsScoreable = TRUE
-                                    AND IsPassed = TRUE
-                                    AND SubmissionStatus != {(int)SubmissionStatus.Failed}
-                                    AND SubmissionStatus != {(int)SubmissionStatus.Deleted}
-                                    AND SubmissionStatus != {(int)SubmissionStatus.Unknown}
-                                    AND Id != {excludeId}
-                                  FOR UPDATE
-                                  """)
+            .FilterValidScores()
+            .FilterPassedScoreableScores()
+            .Where(s => s.UserId == userId && s.BeatmapHash == beatmapHash && s.GameMode == gameMode && s.Id != excludeId)
             .AsNoTracking()
+            .ForUpdate()
             .ToListAsync(ct);
 
         foreach (var score in scores)

--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -258,14 +258,15 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
 
         var scoresIds = string.Join(",", scores.Select(s => s.Id));
 
-        await using var connection = dbContext.Database.GetDbConnection();
-        await connection.OpenAsync(ct);
+        var connection = dbContext.Database.GetDbConnection();
+        if (connection.State != System.Data.ConnectionState.Open)
+            await connection.OpenAsync(ct);
 
         var gameModesWithoutScoreMultiplier = GameModeExtensions.GetGameModesWithoutScoreMultiplier();
 
         var orderByValue = gameModesWithoutScoreMultiplier.Contains(scores.FirstOrDefault()?.GameMode ?? GameMode.Standard) ? nameof(Score.PerformancePoints) : nameof(Score.TotalScore);
 
-        var command = connection.CreateCommand();
+        await using var command = connection.CreateCommand();
         command.CommandText = $"""
 
                                        SELECT Id,

--- a/Sunrise.Shared/Database/Seeders/UserSeeder.cs
+++ b/Sunrise.Shared/Database/Seeders/UserSeeder.cs
@@ -120,37 +120,45 @@ public static class UserSeeder
 
         var foreignKeys = await FetchUserForeignKeys(context);
 
-        await context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS=0;");
+        var shouldCloseConnection = context.Database.GetDbConnection().State != System.Data.ConnectionState.Open;
+        if (shouldCloseConnection)
+            await context.Database.OpenConnectionAsync(ct);
 
-        var usersCount = await context.Set<User>().CountAsync(ct);
-
-        var pageSize = 50;
-
-        for (var x = 0;; x++)
+        try
         {
-            var users = context.Set<User>()
-                .OrderByDescending(u => u.Username)
-                .Skip(x * pageSize)
-                .Take(pageSize)
-                .ToList();
+            await context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS=0;", ct);
 
-            var caseStatements = new StringBuilder();
-            var ids = new List<int>();
+            var usersCount = await context.Set<User>().CountAsync(ct);
 
-            foreach (var user in users)
+            var pageSize = 50;
+
+            for (var x = 0;; x++)
             {
-                var oldId = user.Id;
-                var newId = oldId + 1000;
-                ids.Add(oldId);
+                var users = context.Set<User>()
+                    .OrderByDescending(u => u.Username)
+                    .Skip(x * pageSize)
+                    .Take(pageSize)
+                    .ToList();
 
-                caseStatements.Append($" WHEN {oldId} THEN {newId}");
-            }
+                if (users.Count == 0) break;
 
-            var idsCsv = string.Join(", ", ids);
+                var caseStatements = new StringBuilder();
+                var ids = new List<int>();
 
-            foreach (var key in foreignKeys)
-            {
-                var sql = $@"
+                foreach (var user in users)
+                {
+                    var oldId = user.Id;
+                    var newId = oldId + 1000;
+                    ids.Add(oldId);
+
+                    caseStatements.Append($" WHEN {oldId} THEN {newId}");
+                }
+
+                var idsCsv = string.Join(", ", ids);
+
+                foreach (var key in foreignKeys)
+                {
+                    var sql = $@"
                             UPDATE {key.Item1}
                             SET {key.Item2} = CASE {key.Item2}
                                 {caseStatements}
@@ -159,10 +167,10 @@ public static class UserSeeder
                             WHERE {key.Item2} IN ({idsCsv})
                             ";
 
-                await context.Database.ExecuteSqlRawAsync(sql);
-            }
+                    await context.Database.ExecuteSqlRawAsync(sql, ct);
+                }
 
-            var userUpdateSql = $@"
+                var userUpdateSql = $@"
                                 UPDATE `user`
                                 SET Id = CASE Id
                                     {caseStatements}
@@ -171,14 +179,20 @@ public static class UserSeeder
                                 WHERE Id IN ({idsCsv})
                                 ";
 
-            await context.Database.ExecuteSqlRawAsync(userUpdateSql);
+                await context.Database.ExecuteSqlRawAsync(userUpdateSql, ct);
 
-            logger.Information("Users updated: {usersUpdated} / {usersTotal}.", x * pageSize + users.Count, usersCount);
+                logger.Information("Users updated: {usersUpdated} / {usersTotal}.", x * pageSize + users.Count, usersCount);
 
-            if (users.Count < pageSize) break;
+                if (users.Count < pageSize) break;
+            }
         }
+        finally
+        {
+            await context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS=1;", ct);
 
-        await context.Database.ExecuteSqlRawAsync("SET FOREIGN_KEY_CHECKS=1;");
+            if (shouldCloseConnection)
+                await context.Database.CloseConnectionAsync();
+        }
 
         logger.Information("All user ids were updated to new ID format.");
 

--- a/Sunrise.Shared/Database/Services/Users/UserStatsRanksService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserStatsRanksService.cs
@@ -100,8 +100,8 @@ public class UserStatsRanksService(Lazy<DatabaseService> databaseService, Sunris
 
             await Task.WhenAll(globalRankTask, countryRankTask);
 
-            var globalRank = globalRankTask.Result;
-            var countryRank = countryRankTask.Result;
+            var globalRank = await globalRankTask;
+            var countryRank = await countryRankTask;
 
             try
             {

--- a/Sunrise.Shared/Database/SunriseDbContext.cs
+++ b/Sunrise.Shared/Database/SunriseDbContext.cs
@@ -107,7 +107,7 @@ public class SunriseDbContext : DbContext
     {
         if (!optionsBuilder.IsConfigured)
         {
-            optionsBuilder.UseMySQL(Configuration.DatabaseConnectionString);
+            optionsBuilder.UseMySql(Configuration.DatabaseConnectionString, ServerVersion.AutoDetect(Configuration.DatabaseConnectionString));
         }
     }
 }

--- a/Sunrise.Shared/Extensions/Users/UsernameExtensions.cs
+++ b/Sunrise.Shared/Extensions/Users/UsernameExtensions.cs
@@ -32,7 +32,7 @@ public static class UsernameExtensions
             return (false, "Username contains unallowed strings, please remove them and try again.");
         }
 
-        if (IsUsernameDisallowed(str).Result)
+        if (IsUsernameDisallowed(str))
         {
             return (false, "Username contains unallowed strings, try to come up with a harmless and original nickname.");
         }
@@ -55,7 +55,7 @@ public static class UsernameExtensions
         return Regex.IsMatch(str, @"^[1-9 0-\[\]a-zA-Z_-]+$");
     }
 
-    private static async Task<bool> IsUsernameDisallowed(string str)
+    private static bool IsUsernameDisallowed(string str)
     {
         var path = Path.Combine(Configuration.DataPath, Configuration.BannedUsernamesName);
 
@@ -64,7 +64,7 @@ public static class UsernameExtensions
             return false;
         }
 
-        var bannedUsernames = await File.ReadAllLinesAsync(path, Encoding.UTF8);
+        var bannedUsernames = File.ReadAllLines(path, Encoding.UTF8);
 
         for (var i = 0; i < bannedUsernames.Length; i++)
         {

--- a/Sunrise.Shared/Objects/Chat/ChatRateLimiter.cs
+++ b/Sunrise.Shared/Objects/Chat/ChatRateLimiter.cs
@@ -16,14 +16,12 @@ public class ChatRateLimiter(int messagesLimit, TimeSpan timeWindow, bool action
     public new bool CanSend(BaseSession session)
     {
         var canSend = base.CanSend(session);
-        
+
         using var scope = ServicesProviderHolder.CreateScope();
-        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
-        
-        var user = database.Users
-            .GetUser(id: session.UserId, options: new QueryOptions(true))
-            .ConfigureAwait(false).GetAwaiter().GetResult();
-        
+        var dbContext = scope.ServiceProvider.GetRequiredService<SunriseDbContext>();
+
+        var user = dbContext.Users.FirstOrDefault(u => u.Id == session.UserId);
+
         if (user == null)
             return false;
 

--- a/Sunrise.Shared/Objects/ReplayFile.cs
+++ b/Sunrise.Shared/Objects/ReplayFile.cs
@@ -27,8 +27,8 @@ public class ReplayFile
         if (user == null)
         {
             using var scope = ServicesProviderHolder.CreateScope();
-            var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
-            User = database.Users.GetUser(score.UserId).Result;
+            var dbContext = scope.ServiceProvider.GetRequiredService<SunriseDbContext>();
+            User = dbContext.Users.FirstOrDefault(u => u.Id == score.UserId);
         }
 
         if (User == null)

--- a/Sunrise.Shared/Objects/Sessions/Session.cs
+++ b/Sunrise.Shared/Objects/Sessions/Session.cs
@@ -234,9 +234,9 @@ public class Session : BaseSession
     private User? GetSessionUser()
     {
         using var scope = ServicesProviderHolder.CreateScope();
-        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SunriseDbContext>();
 
-        var user = database.Users.GetUser(UserId, options: new QueryOptions(true)).ConfigureAwait(false).GetAwaiter().GetResult();
+        var user = dbContext.Users.FirstOrDefault(u => u.Id == UserId);
 
         if (user == null)
             throw new ApplicationException($"User with id {UserId} not found");

--- a/Sunrise.Shared/Repositories/ChatChannelRepository.cs
+++ b/Sunrise.Shared/Repositories/ChatChannelRepository.cs
@@ -95,13 +95,13 @@ public class ChatChannelRepository
         {
             return _channels.Values.Where(x => x.IsPublic).ToList();
         }
-        
+
         using var scope = ServicesProviderHolder.CreateScope();
-        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SunriseDbContext>();
 
         var sessionPrivilege = UserPrivilege.User;
 
-        var user = database.Users.GetUser(id: session.UserId, options: new QueryOptions(true)).ConfigureAwait(false).GetAwaiter().GetResult();
+        var user = dbContext.Users.FirstOrDefault(u => u.Id == session.UserId);
         if (user != null)
             sessionPrivilege = user.Privilege;
 

--- a/Sunrise.Shared/Sunrise.Shared.csproj
+++ b/Sunrise.Shared/Sunrise.Shared.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="3.5.1"/>
         <PackageReference Include="DotNetEnv" Version="3.1.1"/>
         <PackageReference Include="EFCoreSecondLevelCacheInterceptor.StackExchange.Redis" Version="5.2.1"/>
+        <PackageReference Include="EntityFrameworkCore.Locking.MySql" Version="0.4.1"/>
         <PackageReference Include="Hangfire.AspNetCore" Version="1.8.18"/>
         <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3"/>
         <PackageReference Include="HoLLy.osu.HOPEless" Version="2.2.0"/>

--- a/Sunrise.Shared/Sunrise.Shared.csproj
+++ b/Sunrise.Shared/Sunrise.Shared.csproj
@@ -18,15 +18,15 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.22"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22"/>
-        <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.9"/>
         <PackageReference Include="MySqlBackup.NET" Version="2.7.0"/>
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.1-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.15.1-beta.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.1-beta.1"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.15.1-beta.1"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1"/>
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3"/>
         <PackageReference Include="Rougamo.OpenTelemetry" Version="5.0.0"/>
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>
         <PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0"/>

--- a/Sunrise.Tests/Extensions/ScoreExtensions.cs
+++ b/Sunrise.Tests/Extensions/ScoreExtensions.cs
@@ -18,9 +18,9 @@ public static class ScoreExtensions
         score.UserId = session.UserId;
 
         using var scope = ServicesProviderHolder.CreateScope();
-        var database = scope.ServiceProvider.GetRequiredService<DatabaseService>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<SunriseDbContext>();
 
-        var user = database.Users.GetUser(id: session.UserId).Result;
+        var user = dbContext.Users.FirstOrDefault(u => u.Id == session.UserId);
         if (user == null)
             throw new NullReferenceException("User not found");
 

--- a/Sunrise.Tests/SunriseServerFactory.cs
+++ b/Sunrise.Tests/SunriseServerFactory.cs
@@ -1,3 +1,4 @@
+using EntityFrameworkCore.Locking.MySql;
 using Hangfire;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -29,6 +30,7 @@ public class SunriseServerFactory : WebApplicationFactory<Server.Program>, IDisp
             {
                 options.EnableServiceProviderCaching(false);
                 options.EnableSensitiveDataLogging();
+                options.UseLocking();
 
                 options.UseMySql(Configuration.DatabaseConnectionString, ServerVersion.AutoDetect(Configuration.DatabaseConnectionString));
             });
@@ -58,7 +60,7 @@ public class SunriseServerFactory : WebApplicationFactory<Server.Program>, IDisp
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing == false)
+        if (!disposing)
         {
             base.Dispose(disposing);
             return;

--- a/Sunrise.Tests/SunriseServerFactory.cs
+++ b/Sunrise.Tests/SunriseServerFactory.cs
@@ -30,7 +30,7 @@ public class SunriseServerFactory : WebApplicationFactory<Server.Program>, IDisp
                 options.EnableServiceProviderCaching(false);
                 options.EnableSensitiveDataLogging();
 
-                options.UseMySQL(Configuration.DatabaseConnectionString);
+                options.UseMySql(Configuration.DatabaseConnectionString, ServerVersion.AutoDetect(Configuration.DatabaseConnectionString));
             });
 
             var httpClientDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(HttpClientService));


### PR DESCRIPTION
We are migrating from Oracle `MySql.EntityFrameworkCore` provider to `Pomelo.EntityFrameworkCore.MySql`.

One of the main reasons to do is the performance, since the Pomelo's provider using [MySqlConnector](https://mysqlconnector.net/) which is far more superior to the Oracle's MySQL.Data.

<img width="2870" height="1771" alt="image" src="https://github.com/user-attachments/assets/034e8204-3dda-466b-84ed-38a7cf3877bd" />

I also added `EntityFrameworkCore.Locking.MySq` package, which is more native way to add DB locking for rows in EF Core, without writing custom raw query. Props to [mnbuhl](https://github.com/mnbuhl).

MySqlConnector is also more sensitive to any DB connections running in sync, this is why there is multiple code changes with fixing this. 

As non related change, we also now check user authorisation before streaming replay data in osu! client endpoint.
