### PR TITLE
Lock user stats/grades for update

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,66 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.0.x
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-      - name: Restore dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --no-restore
-      - name: Pack build artifacts
-        run: |
-          while IFS= read -r -d '' PROJECT; do
-            PROJECT_DIR=$(dirname "$PROJECT")
-            [ -d "$PROJECT_DIR/bin" ] && printf '%s\0' "$PROJECT_DIR/bin"
-            [ -d "$PROJECT_DIR/obj" ] && printf '%s\0' "$PROJECT_DIR/obj"
-          done < <(find . -name '*.csproj' -print0) | tar --null -czf build-artifacts.tar.gz --files-from -
-      - name: Pack Docker test images
-        run: |
-          readarray -t DOCKER_IMAGES < <(docker compose -f docker-compose.tests.yml config --images | sort -u)
-
-          if [ "${#DOCKER_IMAGES[@]}" -eq 0 ]; then
-            echo "::error title=No Docker images found::docker-compose.tests.yml did not resolve any images"
-            exit 1
-          fi
-
-          echo "Docker test images:"
-          printf '  %s\n' "${DOCKER_IMAGES[@]}"
-
-          for IMAGE in "${DOCKER_IMAGES[@]}"; do
-            docker pull "$IMAGE"
-          done
-
-          docker save "${DOCKER_IMAGES[@]}" | gzip > docker-test-images.tar.gz
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: build-artifacts.tar.gz
-          retention-days: 1
-      - name: Upload Docker test images
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-test-images
-          path: docker-test-images.tar.gz
-          retention-days: 1
-
   test:
     name: Test Group ${{ matrix.group }}
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -95,13 +37,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
       - name: Restore test dependencies
         run: dotnet restore
       - name: Download build artifacts
@@ -117,7 +52,7 @@ jobs:
       - name: Load Docker test images
         run: docker load --input docker-test-images.tar.gz
       - name: Docker compose test environment
-        run: docker compose -f docker-compose.tests.yml up -d --wait --pull never
+        run: docker compose -f docker-compose.tests.yml up -d --wait
       - name: Run tests (Group ${{ matrix.group }}/16)
         env:
           TEST_GROUP: ${{ matrix.group }}
@@ -132,38 +67,25 @@ jobs:
           
           echo "Found $TOTAL test files total"
           
-          # Build filters for this group's test classes, grouped by owning test project.
+          # Build filter for this group's test classes
           FILTER=""
-          ASSIGNED_COUNT=0
-          declare -A PROJECT_FILTERS
-
           for i in "${!FILES_ARRAY[@]}"; do
             if [ $(( (i % TEST_TOTAL_GROUPS) + 1 )) -eq $TEST_GROUP ]; then
               FILE="${FILES_ARRAY[$i]}"
+              # Extract class name from filename
               CLASS=$(basename "$FILE" .cs)
-              PROJECT_DIR=${FILE#./}
-              PROJECT_DIR=${PROJECT_DIR%%/*}
-
               if [ -n "$CLASS" ]; then
                 echo "  - $CLASS"
-                ASSIGNED_COUNT=$((ASSIGNED_COUNT + 1))
-
                 if [ -z "$FILTER" ]; then
                   FILTER="FullyQualifiedName~$CLASS"
                 else
                   FILTER="$FILTER|FullyQualifiedName~$CLASS"
                 fi
-
-                if [ -z "${PROJECT_FILTERS[$PROJECT_DIR]:-}" ]; then
-                  PROJECT_FILTERS[$PROJECT_DIR]="FullyQualifiedName~$CLASS"
-                else
-                  PROJECT_FILTERS[$PROJECT_DIR]="${PROJECT_FILTERS[$PROJECT_DIR]}|FullyQualifiedName~$CLASS"
-                fi
               fi
             fi
           done
           
-          if [ "$ASSIGNED_COUNT" -eq 0 ]; then
+          if [ -z "$FILTER" ]; then
             echo "No tests assigned to group $TEST_GROUP"
             exit 0
           fi
@@ -175,39 +97,15 @@ jobs:
           
           FAILED=0
           
-          for PROJECT_DIR in $(printf '%s\n' "${!PROJECT_FILTERS[@]}" | sort); do
-            TEST_PROJECT=$(find "$PROJECT_DIR" -maxdepth 1 -name '*.csproj' -print -quit)
-            PROJECT_FILTER=${PROJECT_FILTERS[$PROJECT_DIR]}
-
-            echo ""
-            echo "=== Running $PROJECT_DIR ==="
-
-            if [ -z "$TEST_PROJECT" ]; then
-              echo "::error title=Missing test project::No .csproj found for assigned test directory $PROJECT_DIR"
-              FAILED=1
-              continue
-            fi
-
-            echo "Project filter: $PROJECT_FILTER"
-
-            if dotnet test "$TEST_PROJECT" --no-build --no-restore --verbosity normal --filter "$PROJECT_FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
-              TEST_EXIT=0
-            else
-              TEST_EXIT=$?
-            fi
-
-            echo "$PROJECT_DIR dotnet test exit code: $TEST_EXIT"
-
-            if [ "$TEST_EXIT" -ne 0 ]; then
-              echo "::error title=dotnet test failed::$PROJECT_DIR exited with code $TEST_EXIT"
-              FAILED=1
-            fi
-          done
-
-          if [ "$FAILED" -ne 0 ]; then
-            echo "One or more assigned test projects failed."
-          else
-            echo "All assigned test projects passed."
+          echo "=== Running Sunrise.Shared.Tests ==="
+          if ! dotnet test Sunrise.Shared.Tests/Sunrise.Shared.Tests.csproj --no-build --verbosity normal --filter "$FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
+            FAILED=1
+          fi
+          
+          echo ""
+          echo "=== Running Sunrise.Server.Tests ==="
+          if ! dotnet test Sunrise.Server.Tests/Sunrise.Server.Tests.csproj --no-build --verbosity normal --filter "$FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
+            FAILED=1
           fi
           
           exit $FAILED

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,22 +37,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-      - name: Restore test dependencies
-        run: dotnet restore
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-      - name: Extract build artifacts
-        run: tar -xzf build-artifacts.tar.gz
-      - name: Download Docker test images
-        uses: actions/download-artifact@v4
-        with:
-          name: docker-test-images
-      - name: Load Docker test images
-        run: docker load --input docker-test-images.tar.gz
       - name: Docker compose test environment
-        run: docker compose -f docker-compose.tests.yml up -d --wait
+        run: docker compose -f docker-compose.tests.yml up -d
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
       - name: Run tests (Group ${{ matrix.group }}/16)
         env:
           TEST_GROUP: ${{ matrix.group }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,13 +25,18 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore
+      - name: Pack build artifacts
+        run: |
+          while IFS= read -r -d '' PROJECT; do
+            PROJECT_DIR=$(dirname "$PROJECT")
+            [ -d "$PROJECT_DIR/bin" ] && printf '%s\0' "$PROJECT_DIR/bin"
+            [ -d "$PROJECT_DIR/obj" ] && printf '%s\0' "$PROJECT_DIR/obj"
+          done < <(find . -name '*.csproj' -print0) | tar --null -czf build-artifacts.tar.gz --files-from -
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
-          path: |
-            **/bin/
-            **/obj/
+          path: build-artifacts.tar.gz
           retention-days: 1
 
   test:
@@ -67,10 +72,21 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Restore test dependencies
+        run: dotnet restore
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
+      - name: Extract build artifacts
+        run: tar -xzf build-artifacts.tar.gz
       - name: Docker compose test environment
         run: docker compose -f docker-compose.tests.yml up -d --wait
       - name: Run tests (Group ${{ matrix.group }}/16)
@@ -116,16 +132,40 @@ jobs:
           echo ""
           
           FAILED=0
+          readarray -t TEST_PROJECTS < <(find . -maxdepth 2 -path './*.Tests/*.csproj' -printf '%P\n' | sort)
           
-          echo "=== Running Sunrise.Shared.Tests ==="
-          if ! dotnet test Sunrise.Shared.Tests/Sunrise.Shared.Tests.csproj --no-build --verbosity normal --filter "$FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
-            FAILED=1
-          fi
-          
-          echo ""
-          echo "=== Running Sunrise.Server.Tests ==="
-          if ! dotnet test Sunrise.Server.Tests/Sunrise.Server.Tests.csproj --no-build --verbosity normal --filter "$FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
-            FAILED=1
-          fi
+          for TEST_PROJECT in "${TEST_PROJECTS[@]}"; do
+            PROJECT_DIR=$(dirname "$TEST_PROJECT")
+            PROJECT_FILTER=""
+
+            for i in "${!FILES_ARRAY[@]}"; do
+              if [ $(( (i % TEST_TOTAL_GROUPS) + 1 )) -ne $TEST_GROUP ]; then
+                continue
+              fi
+
+              FILE="${FILES_ARRAY[$i]}"
+              if [[ "$FILE" != "./$PROJECT_DIR/"* ]]; then
+                continue
+              fi
+
+              CLASS=$(basename "$FILE" .cs)
+              if [ -z "$PROJECT_FILTER" ]; then
+                PROJECT_FILTER="FullyQualifiedName~$CLASS"
+              else
+                PROJECT_FILTER="$PROJECT_FILTER|FullyQualifiedName~$CLASS"
+              fi
+            done
+
+            echo ""
+            echo "=== Running $PROJECT_DIR ==="
+            if [ -z "$PROJECT_FILTER" ]; then
+              echo "No tests assigned to $PROJECT_DIR in group $TEST_GROUP"
+              continue
+            fi
+
+            if ! dotnet test "$TEST_PROJECT" --no-build --no-restore --verbosity normal --filter "$PROJECT_FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
+              FAILED=1
+            fi
+          done
           
           exit $FAILED

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,11 +32,34 @@ jobs:
             [ -d "$PROJECT_DIR/bin" ] && printf '%s\0' "$PROJECT_DIR/bin"
             [ -d "$PROJECT_DIR/obj" ] && printf '%s\0' "$PROJECT_DIR/obj"
           done < <(find . -name '*.csproj' -print0) | tar --null -czf build-artifacts.tar.gz --files-from -
+      - name: Pack Docker test images
+        run: |
+          readarray -t DOCKER_IMAGES < <(docker compose -f docker-compose.tests.yml config --images | sort -u)
+
+          if [ "${#DOCKER_IMAGES[@]}" -eq 0 ]; then
+            echo "::error title=No Docker images found::docker-compose.tests.yml did not resolve any images"
+            exit 1
+          fi
+
+          echo "Docker test images:"
+          printf '  %s\n' "${DOCKER_IMAGES[@]}"
+
+          for IMAGE in "${DOCKER_IMAGES[@]}"; do
+            docker pull "$IMAGE"
+          done
+
+          docker save "${DOCKER_IMAGES[@]}" | gzip > docker-test-images.tar.gz
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: build-artifacts.tar.gz
+          retention-days: 1
+      - name: Upload Docker test images
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-test-images
+          path: docker-test-images.tar.gz
           retention-days: 1
 
   test:
@@ -87,8 +110,14 @@ jobs:
           name: build-artifacts
       - name: Extract build artifacts
         run: tar -xzf build-artifacts.tar.gz
+      - name: Download Docker test images
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-test-images
+      - name: Load Docker test images
+        run: docker load --input docker-test-images.tar.gz
       - name: Docker compose test environment
-        run: docker compose -f docker-compose.tests.yml up -d --wait
+        run: docker compose -f docker-compose.tests.yml up -d --wait --pull never
       - name: Run tests (Group ${{ matrix.group }}/16)
         env:
           TEST_GROUP: ${{ matrix.group }}
@@ -103,25 +132,38 @@ jobs:
           
           echo "Found $TOTAL test files total"
           
-          # Build filter for this group's test classes
+          # Build filters for this group's test classes, grouped by owning test project.
           FILTER=""
+          ASSIGNED_COUNT=0
+          declare -A PROJECT_FILTERS
+
           for i in "${!FILES_ARRAY[@]}"; do
             if [ $(( (i % TEST_TOTAL_GROUPS) + 1 )) -eq $TEST_GROUP ]; then
               FILE="${FILES_ARRAY[$i]}"
-              # Extract class name from filename
               CLASS=$(basename "$FILE" .cs)
+              PROJECT_DIR=${FILE#./}
+              PROJECT_DIR=${PROJECT_DIR%%/*}
+
               if [ -n "$CLASS" ]; then
                 echo "  - $CLASS"
+                ASSIGNED_COUNT=$((ASSIGNED_COUNT + 1))
+
                 if [ -z "$FILTER" ]; then
                   FILTER="FullyQualifiedName~$CLASS"
                 else
                   FILTER="$FILTER|FullyQualifiedName~$CLASS"
                 fi
+
+                if [ -z "${PROJECT_FILTERS[$PROJECT_DIR]:-}" ]; then
+                  PROJECT_FILTERS[$PROJECT_DIR]="FullyQualifiedName~$CLASS"
+                else
+                  PROJECT_FILTERS[$PROJECT_DIR]="${PROJECT_FILTERS[$PROJECT_DIR]}|FullyQualifiedName~$CLASS"
+                fi
               fi
             fi
           done
           
-          if [ -z "$FILTER" ]; then
+          if [ "$ASSIGNED_COUNT" -eq 0 ]; then
             echo "No tests assigned to group $TEST_GROUP"
             exit 0
           fi
@@ -132,40 +174,40 @@ jobs:
           echo ""
           
           FAILED=0
-          readarray -t TEST_PROJECTS < <(find . -maxdepth 2 -path './*.Tests/*.csproj' -printf '%P\n' | sort)
           
-          for TEST_PROJECT in "${TEST_PROJECTS[@]}"; do
-            PROJECT_DIR=$(dirname "$TEST_PROJECT")
-            PROJECT_FILTER=""
-
-            for i in "${!FILES_ARRAY[@]}"; do
-              if [ $(( (i % TEST_TOTAL_GROUPS) + 1 )) -ne $TEST_GROUP ]; then
-                continue
-              fi
-
-              FILE="${FILES_ARRAY[$i]}"
-              if [[ "$FILE" != "./$PROJECT_DIR/"* ]]; then
-                continue
-              fi
-
-              CLASS=$(basename "$FILE" .cs)
-              if [ -z "$PROJECT_FILTER" ]; then
-                PROJECT_FILTER="FullyQualifiedName~$CLASS"
-              else
-                PROJECT_FILTER="$PROJECT_FILTER|FullyQualifiedName~$CLASS"
-              fi
-            done
+          for PROJECT_DIR in $(printf '%s\n' "${!PROJECT_FILTERS[@]}" | sort); do
+            TEST_PROJECT=$(find "$PROJECT_DIR" -maxdepth 1 -name '*.csproj' -print -quit)
+            PROJECT_FILTER=${PROJECT_FILTERS[$PROJECT_DIR]}
 
             echo ""
             echo "=== Running $PROJECT_DIR ==="
-            if [ -z "$PROJECT_FILTER" ]; then
-              echo "No tests assigned to $PROJECT_DIR in group $TEST_GROUP"
+
+            if [ -z "$TEST_PROJECT" ]; then
+              echo "::error title=Missing test project::No .csproj found for assigned test directory $PROJECT_DIR"
+              FAILED=1
               continue
             fi
 
-            if ! dotnet test "$TEST_PROJECT" --no-build --no-restore --verbosity normal --filter "$PROJECT_FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
+            echo "Project filter: $PROJECT_FILTER"
+
+            if dotnet test "$TEST_PROJECT" --no-build --no-restore --verbosity normal --filter "$PROJECT_FILTER" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"; then
+              TEST_EXIT=0
+            else
+              TEST_EXIT=$?
+            fi
+
+            echo "$PROJECT_DIR dotnet test exit code: $TEST_EXIT"
+
+            if [ "$TEST_EXIT" -ne 0 ]; then
+              echo "::error title=dotnet test failed::$PROJECT_DIR exited with code $TEST_EXIT"
               FAILED=1
             fi
           done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "One or more assigned test projects failed."
+          else
+            echo "All assigned test projects passed."
+          fi
           
           exit $FAILED

--- a/Sunrise.Processing.Tests/Scores/Processors/UserGradesScoreProcessorTests.cs
+++ b/Sunrise.Processing.Tests/Scores/Processors/UserGradesScoreProcessorTests.cs
@@ -230,6 +230,41 @@ public class UserGradesScoreProcessorTests(IntegrationDatabaseFixture fixture) :
     }
 
     [Fact]
+    public async Task TestOnDeletionWithPromotedReplacementWithSameGradeNoChangesRequired()
+    {
+        // Arrange
+        var processor = new UserGradesScoreProcessor(Database);
+        var user = await CreateTestUser();
+        var userStats = await Database.Users.Stats.GetUserStats(user.Id, GameMode.Standard);
+        Assert.NotNull(userStats);
+        var userGrades = new UserGrades
+        {
+            UserId = user.Id,
+            GameMode = GameMode.Standard,
+            CountA = 1
+        };
+
+        var promotedReplacement = CreateScore(user, submissionStatus: SubmissionStatus.Best);
+        var score = CreateScore(user);
+        var originalState = ScoreStateSnapshot.Capture(score);
+
+        var context = ScoreCommitContextFactory.Create(
+            ScoreTaskType.Delete,
+            score,
+            user,
+            userStats,
+            userGrades,
+            userPersonalBestScores: new UserBeatmapPeers(new UserPersonalBestScores(promotedReplacement), new UserPersonalBestScores(promotedReplacement)),
+            originalState: originalState);
+
+        // Act
+        await processor.OnDeletion(context);
+
+        // Assert
+        Assert.Equal(1, userGrades.CountA);
+    }
+
+    [Fact]
     public async Task TestOnDeletionWithNonBestOriginalStateKeepsGradesUnchanged()
     {
         // Arrange

--- a/Sunrise.Processing/Scores/Pipeline/ScoreCommitPipeline.cs
+++ b/Sunrise.Processing/Scores/Pipeline/ScoreCommitPipeline.cs
@@ -56,6 +56,9 @@ public class ScoreCommitPipeline
 
         ctx.UserPersonalBestScores = peers;
 
+        await _database.Users.Stats.LockAndRefreshUserStats(ctx.UserStats, ct);
+        await _database.Users.Grades.LockAndRefreshUserGrades(ctx.UserGrades, ct);
+
         foreach (var processor in _processors)
         {
             await DispatchProcessor(processor, ctx);

--- a/Sunrise.Processing/Scores/Processors/UserGradesScoreProcessor.cs
+++ b/Sunrise.Processing/Scores/Processors/UserGradesScoreProcessor.cs
@@ -39,6 +39,8 @@ public class UserGradesScoreProcessor(DatabaseService database) : ScoreEntityPro
 
     protected override async Task AfterExecution(ScoreCommitContext ctx)
     {
+        // NOTE: Ideally we should have atomic update here, but we have an assumption that pp calculation and beatmap retrieval would
+        // be the heaviest operations. Thus, just relying on lock FOR UPDATES is enough in this context.
         var updateUserGradesResult = await database.Users.Grades.UpdateUserGrades(ctx.UserGrades);
         if (updateUserGradesResult.IsFailure)
             throw new ApplicationException("Failed to persist user grades: " + updateUserGradesResult.Error);
@@ -77,10 +79,10 @@ public class UserGradesScoreProcessor(DatabaseService database) : ScoreEntityPro
         if (!IsOverallBestScore(score, promotedOverallBest))
             return;
 
-        UpdateUserGradesCount(userGrades, score.Grade, -1);
-
         if (promotedOverallBest != null)
             UpdateUserGradesCount(userGrades, promotedOverallBest.Grade, 1);
+
+        UpdateUserGradesCount(userGrades, score.Grade, -1);
     }
 
     private static bool IsOverallBestScore(Score score, Score? peer)
@@ -99,6 +101,9 @@ public class UserGradesScoreProcessor(DatabaseService database) : ScoreEntityPro
 
     private static void UpdateUserGradesCount(UserGrades userGrades, string grade, int delta)
     {
+        if (delta is > 1 or < -1)
+            throw new ArgumentOutOfRangeException(nameof(delta));
+
         switch (grade)
         {
             case "XH": userGrades.CountXH = Math.Max(0, userGrades.CountXH + delta); break;

--- a/Sunrise.Processing/Scores/Processors/UserGradesScoreProcessor.cs
+++ b/Sunrise.Processing/Scores/Processors/UserGradesScoreProcessor.cs
@@ -59,6 +59,10 @@ public class UserGradesScoreProcessor(DatabaseService database) : ScoreEntityPro
         if (!IsOverallBestScore(score, previousOverallBest))
             return;
 
+        // If the grade hasn't changed, we can return early and skip any DB calls.
+        if (previousOverallBest?.Grade == score.Grade)
+            return;
+
         if (previousOverallBest != null)
             UpdateUserGradesCount(userGrades, previousOverallBest.Grade, -1);
 
@@ -77,6 +81,10 @@ public class UserGradesScoreProcessor(DatabaseService database) : ScoreEntityPro
             return;
 
         if (!IsOverallBestScore(score, promotedOverallBest))
+            return;
+
+        // If the grade hasn't changed, we can return early and skip any DB calls.
+        if (promotedOverallBest?.Grade == score.Grade)
             return;
 
         if (promotedOverallBest != null)

--- a/Sunrise.Processing/Scores/Processors/UserStatsScoreProcessor.cs
+++ b/Sunrise.Processing/Scores/Processors/UserStatsScoreProcessor.cs
@@ -42,6 +42,8 @@ public class UserStatsScoreProcessor(
 
     protected override async Task AfterExecution(ScoreCommitContext ctx)
     {
+        // NOTE: Ideally we should have atomic update here, but we have an assumption that pp calculation and beatmap retrieval would
+        // be the heaviest operations. Thus, just relying on lock FOR UPDATES is enough in this context.
         var updateUserStatsResult = await database.Users.Stats.UpdateUserStats(ctx.UserStats, ctx.User);
         if (updateUserStatsResult.IsFailure)
             throw new ApplicationException("Failed to persist user stats: " + updateUserStatsResult.Error);

--- a/Sunrise.Shared/Database/DatabaseService.cs
+++ b/Sunrise.Shared/Database/DatabaseService.cs
@@ -35,6 +35,12 @@ public sealed class DatabaseService(
     public readonly ScoreSubmissionRequestRepository ScoreSubmissionRequests = scoreSubmissionRequestRepository;
     public readonly ScoreProcessingTaskRepository ScoreProcessingTasks = scoreProcessingTaskRepository;
     public readonly UserRepository Users = userRepository;
+    private readonly List<Func<Task>> _afterCommitActions = [];
+
+    public void RegisterAfterCommitAction(Func<Task> action)
+    {
+        _afterCommitActions.Add(action);
+    }
 
     public async Task FlushAndUpdateRedisCache(bool isSoftFlush = true)
     {
@@ -100,7 +106,10 @@ public sealed class DatabaseService(
             await DbContext.SaveChangesAsync();
 
             if (!isCurrentlyInOtherTransactionScope && transaction != null)
+            {
                 await transaction.CommitAsync(ct);
+                await RunAfterCommitActions();
+            }
 
             return Result.Success();
         }
@@ -109,12 +118,18 @@ public sealed class DatabaseService(
             if (!isCurrentlyInOtherTransactionScope && transaction != null)
                 await transaction.RollbackAsync(ct);
 
+            if (!isCurrentlyInOtherTransactionScope)
+                _afterCommitActions.Clear();
+
             return Result.Failure($"{ex.Message}\n{ex.InnerException?.Message}");
         }
         catch (Exception ex)
         {
             if (!isCurrentlyInOtherTransactionScope && transaction != null)
                 await transaction.RollbackAsync(ct);
+
+            if (!isCurrentlyInOtherTransactionScope)
+                _afterCommitActions.Clear();
 
             logger.LogWarning(ex, "Failed to process db transaction");
 
@@ -147,6 +162,24 @@ public sealed class DatabaseService(
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to invalidate cache after db transaction, affected tables: {AffectedTables}", string.Join(", ", affectedTables));
+            }
+        }
+    }
+
+    private async Task RunAfterCommitActions()
+    {
+        var actions = _afterCommitActions.ToArray();
+        _afterCommitActions.Clear();
+
+        foreach (var action in actions)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to run after-commit database action");
             }
         }
     }

--- a/Sunrise.Shared/Database/Interceptor/SlowQueryLoggerInterceptor.cs
+++ b/Sunrise.Shared/Database/Interceptor/SlowQueryLoggerInterceptor.cs
@@ -28,4 +28,59 @@ public class SlowQueryLoggerInterceptor : DbCommandInterceptor
 
         return base.ReaderExecuted(command, eventData, result);
     }
+
+
+    public override int NonQueryExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result)
+    {
+        if (eventData.Duration.TotalMilliseconds > SlowQueryThresholdMilliseconds)
+        {
+            Log.Warning("Slow Query Detected. ({Milliseconds}ms): {QueryString}", eventData.Duration.TotalMilliseconds, command.CommandText);
+        }
+
+        return base.NonQueryExecuted(command, eventData, result);
+    }
+
+    public override async ValueTask<int> NonQueryExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        int result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Duration.TotalMilliseconds > SlowQueryThresholdMilliseconds)
+        {
+            Log.Warning("Slow Query Detected. ({Milliseconds}ms): {QueryString}", eventData.Duration.TotalMilliseconds, command.CommandText);
+        }
+
+        return await base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override object? ScalarExecuted(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result)
+    {
+        if (eventData.Duration.TotalMilliseconds > SlowQueryThresholdMilliseconds)
+        {
+            Log.Warning("Slow Query Detected. ({Milliseconds}ms): {QueryString}", eventData.Duration.TotalMilliseconds, command.CommandText);
+        }
+
+        return base.ScalarExecuted(command, eventData, result);
+    }
+
+    public override async ValueTask<object?> ScalarExecutedAsync(
+        DbCommand command,
+        CommandExecutedEventData eventData,
+        object? result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Duration.TotalMilliseconds > SlowQueryThresholdMilliseconds)
+        {
+            Log.Warning("Slow Query Detected. ({Milliseconds}ms): {QueryString}", eventData.Duration.TotalMilliseconds, command.CommandText);
+        }
+
+        return await base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+    }
 }

--- a/Sunrise.Shared/Database/Services/Users/UserGradesService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserGradesService.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using EntityFrameworkCore.Locking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sunrise.Shared.Database.Extensions;
@@ -33,6 +34,22 @@ public class UserGradesService(
         });
     }
 
+    public async Task LockAndRefreshUserGrades(UserGrades userGrades, CancellationToken ct = default)
+    {
+        var lockedUserGrades = await dbContext.UserGrades
+            .AsNoTracking()
+            .Where(ug => userGrades.Id != 0
+                ? ug.Id == userGrades.Id
+                : ug.UserId == userGrades.UserId && ug.GameMode == userGrades.GameMode)
+            .ForUpdate()
+            .SingleOrDefaultAsync(ct);
+
+        if (lockedUserGrades == null)
+            return;
+
+        CopyUserGradesValues(lockedUserGrades, userGrades);
+    }
+
     public async Task<UserGrades?> GetUserGrades(int userId, GameMode mode, CancellationToken ct = default)
     {
         var grades = await dbContext.UserGrades.Where(e => e.UserId == userId && e.GameMode == mode).FirstOrDefaultAsync(cancellationToken: ct);
@@ -54,5 +71,18 @@ public class UserGradesService(
         }
 
         return grades;
+    }
+
+    private static void CopyUserGradesValues(UserGrades source, UserGrades target)
+    {
+        target.Id = source.Id;
+        target.CountXH = source.CountXH;
+        target.CountX = source.CountX;
+        target.CountSH = source.CountSH;
+        target.CountS = source.CountS;
+        target.CountA = source.CountA;
+        target.CountB = source.CountB;
+        target.CountC = source.CountC;
+        target.CountD = source.CountD;
     }
 }

--- a/Sunrise.Shared/Database/Services/Users/UserStatsService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserStatsService.cs
@@ -71,6 +71,22 @@ public class UserStatsService(
         return stats;
     }
 
+    public async Task LockAndRefreshUserStats(UserStats stats, CancellationToken ct = default)
+    {
+        var lockedStats = await dbContext.UserStats
+            .AsNoTracking()
+            .Where(us => stats.Id != 0
+                ? us.Id == stats.Id
+                : us.UserId == stats.UserId && us.GameMode == stats.GameMode)
+            .ForUpdate()
+            .SingleOrDefaultAsync(ct);
+
+        if (lockedStats == null)
+            return;
+
+        CopyUserStatsValues(lockedStats, stats);
+    }
+
     public async Task<List<UserStats>> GetUsersStats(GameMode mode, LeaderboardSortType leaderboardSortType, List<int>? userIds = null, QueryOptions? options = null, bool addMissingUserStats = true, CancellationToken ct = default)
     {
         var statsQuery = dbContext.UserStats.Where(e => e.GameMode == mode);
@@ -127,5 +143,27 @@ public class UserStatsService(
         }
 
         return stats;
+    }
+
+    private static void CopyUserStatsValues(UserStats source, UserStats target)
+    {
+        var rank = target.LocalProperties.Rank;
+
+        target.Id = source.Id;
+        target.UserId = source.UserId;
+        target.GameMode = source.GameMode;
+        target.Accuracy = source.Accuracy;
+        target.TotalScore = source.TotalScore;
+        target.RankedScore = source.RankedScore;
+        target.PlayCount = source.PlayCount;
+        target.PerformancePoints = source.PerformancePoints;
+        target.MaxCombo = source.MaxCombo;
+        target.PlayTime = source.PlayTime;
+        target.TotalHits = source.TotalHits;
+        target.BestGlobalRank = source.BestGlobalRank;
+        target.BestGlobalRankDate = source.BestGlobalRankDate;
+        target.BestCountryRank = source.BestCountryRank;
+        target.BestCountryRankDate = source.BestCountryRankDate;
+        target.LocalProperties.Rank = rank;
     }
 }

--- a/Sunrise.Shared/Database/Services/Users/UserStatsService.cs
+++ b/Sunrise.Shared/Database/Services/Users/UserStatsService.cs
@@ -1,4 +1,5 @@
 using CSharpFunctionalExtensions;
+using EntityFrameworkCore.Locking;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sunrise.Shared.Database.Extensions;
@@ -35,16 +36,29 @@ public class UserStatsService(
         });
     }
 
-    public async Task<Result> UpdateUserStats(UserStats stats, User user)
+    public async Task<Result> UpdateUserStats(UserStats stats, User user, CancellationToken ct = default)
     {
         return await ResultUtil.TryExecuteAsync(async () =>
         {
-            var addOrUpdateUserRanksResult = await Ranks.AddOrUpdateUserRanks(stats, user);
-            if (addOrUpdateUserRanksResult.IsFailure)
-                throw new ApplicationException(addOrUpdateUserRanksResult.Error);
-
             dbContext.UpdateEntity(stats);
-            await dbContext.SaveChangesAsync();
+
+            if (dbContext.Database.CurrentTransaction != null)
+            {
+                databaseService.Value.RegisterAfterCommitAction(async () =>
+                {
+                    var addOrUpdateUserRanksResult = await Ranks.AddOrUpdateUserRanks(stats, user);
+                    if (addOrUpdateUserRanksResult.IsFailure)
+                        _logger.LogWarning("Failed to update user ranks after stats update: {Error}", addOrUpdateUserRanksResult.Error);
+                });
+
+                return;
+            }
+
+            await dbContext.SaveChangesAsync(ct);
+
+            var updateRanksResult = await Ranks.AddOrUpdateUserRanks(stats, user);
+            if (updateRanksResult.IsFailure)
+                throw new ApplicationException(updateRanksResult.Error);
         });
     }
 

--- a/Sunrise.Tests/IntegrationDatabaseFixture.cs
+++ b/Sunrise.Tests/IntegrationDatabaseFixture.cs
@@ -51,6 +51,8 @@ public class IntegrationDatabaseFixture : IAsyncLifetime
     public async Task ResetAsync()
     {
         using var scope = App.Server.Services.CreateScope();
+
+        App.MockHttpClient?.ClearMocks();
         
         await ClearSingletonState(scope);
         


### PR DESCRIPTION
In this PR we are going to add lock for user stats and grades during score processing. As both entries are doing increments/decrements, we need to make sure the entities being updates are up-to-date.

I originally wanted to use atomic updates, but in MySQL database there is no good way to update entity and fetch new results as a single query. Another problem is that you can't ask EF Core to handle the atomic update itself, so you need to provide the delta values to the new method, which looks *very sloppy*.

As per my assumption, any score processing update will be blocked by the beatmap retrieval. Si using lock here wouldn't hurt the performance in general.

Another changes:
- [x] I've rolled back the new split implementation of tests workflow, since it wasn't really running the tests. bruh.
- [x] We now apply redis leaderboard update only after the db transaction commit. 
- [x] Early return for the grades processor, if grades are equal for the promoted/demoted score and updated score.
