### PR TITLE
Add final for update locks for score processing

### DIFF
--- a/Sunrise.Processing/Scores/Pipeline/ScoreCommitPipeline.cs
+++ b/Sunrise.Processing/Scores/Pipeline/ScoreCommitPipeline.cs
@@ -38,6 +38,19 @@ public class ScoreCommitPipeline
     {
         var score = ctx.Score;
 
+        await _database.Users.Stats.LockAndRefreshUserStats(ctx.UserStats, ct);
+        await _database.Users.Grades.LockAndRefreshUserGrades(ctx.UserGrades, ct);
+
+        if (ctx.TaskType != ScoreTaskType.Submission)
+        {
+            var newPerformancePoints = score.PerformancePoints;
+            var locked = await _database.Scores.LockAndRefreshScore(score, ct); // TODO: This will cause the deadlocks, since we are first locking the main score and then peers. I'm partially fine with this since we have retries, but we will need to refactor this system some day for one single lock.
+            if (!locked)
+                throw new ApplicationException($"Score {score.Id} was not found while locking score commit target");
+
+            score.PerformancePoints = newPerformancePoints;
+        }
+
         score.LocalProperties = new LocalProperties().FromScore(score);
 
         ctx.OriginalState = ScoreStateSnapshot.Capture(score);
@@ -55,9 +68,6 @@ public class ScoreCommitPipeline
             ct);
 
         ctx.UserPersonalBestScores = peers;
-
-        await _database.Users.Stats.LockAndRefreshUserStats(ctx.UserStats, ct);
-        await _database.Users.Grades.LockAndRefreshUserGrades(ctx.UserGrades, ct);
 
         foreach (var processor in _processors)
         {

--- a/Sunrise.Shared/Application/Configuration.cs
+++ b/Sunrise.Shared/Application/Configuration.cs
@@ -195,8 +195,9 @@ public static class Configuration
     public static int ScoreProcessingTimeoutSeconds =>
         Config.GetSection("ScoreProcessing").GetValue<int?>("TimeoutSeconds") ?? 10;
 
+    // NOTE: Concurrency is disabled by default. See https://github.com/SunriseCommunity/Sunrise/pull/127 for reason
     public static int ScoreProcessingMaxConcurrency =>
-        Config.GetSection("ScoreProcessing").GetValue<int?>("MaxConcurrency") ?? 3;
+        Config.GetSection("ScoreProcessing").GetValue<int?>("MaxConcurrency") ?? 1;
 
     public static int ScoreProcessingPollerInterBatchDelaySeconds =>
         Config.GetSection("ScoreProcessing").GetValue<int?>("PollerInterBatchDelaySeconds")

--- a/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
+++ b/Sunrise.Shared/Database/Repositories/ScoreRepository.cs
@@ -43,6 +43,24 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
         });
     }
 
+    public async Task<bool> LockAndRefreshScore(Score score, CancellationToken ct = default)
+    {
+        if (score.Id == 0)
+            return false;
+
+        var lockedScore = await dbContext.Scores
+            .AsNoTracking()
+            .Where(s => s.Id == score.Id)
+            .ForUpdate()
+            .SingleOrDefaultAsync(ct);
+
+        if (lockedScore == null)
+            return false;
+
+        CopyScoreValues(lockedScore, score);
+        return true;
+    }
+
     public async Task<(List<Score>, int)> GetBestScoresByGameMode(GameMode mode, QueryOptions? options = null, CancellationToken ct = default)
     {
         var groupedBestScores = dbContext.Scores
@@ -76,6 +94,38 @@ public class ScoreRepository(ILogger<ScoreRepository> logger, SunriseDbContext d
             .Where(s => s.Id == id)
             .UseQueryOptions(options)
             .FirstOrDefaultAsync(cancellationToken: ct);
+    }
+
+    private static void CopyScoreValues(Score source, Score target)
+    {
+        target.Id = source.Id;
+        target.UserId = source.UserId;
+        target.BeatmapId = source.BeatmapId;
+        target.ScoreHash = source.ScoreHash;
+        target.BeatmapHash = source.BeatmapHash;
+        target.ReplayFileId = source.ReplayFileId;
+        target.TotalScore = source.TotalScore;
+        target.MaxCombo = source.MaxCombo;
+        target.Count300 = source.Count300;
+        target.Count100 = source.Count100;
+        target.Count50 = source.Count50;
+        target.CountMiss = source.CountMiss;
+        target.CountKatu = source.CountKatu;
+        target.CountGeki = source.CountGeki;
+        target.Perfect = source.Perfect;
+        target.Mods = source.Mods;
+        target.Grade = source.Grade;
+        target.IsPassed = source.IsPassed;
+        target.IsScoreable = source.IsScoreable;
+        target.SubmissionStatus = source.SubmissionStatus;
+        target.GameMode = source.GameMode;
+        target.WhenPlayed = source.WhenPlayed;
+        target.OsuVersion = source.OsuVersion;
+        target.BeatmapStatus = source.BeatmapStatus;
+        target.ClientTime = source.ClientTime;
+        target.Accuracy = source.Accuracy;
+        target.PerformancePoints = source.PerformancePoints;
+        target.TimeElapsed = source.TimeElapsed;
     }
 
     public async Task<Score?> GetScore(string scoreHash, QueryOptions? options = null, CancellationToken ct = default)


### PR DESCRIPTION
Addition to the https://github.com/SunriseCommunity/Sunrise/pull/126

I thought having locks on peers would be enough, but in practice it's actually not, due to having same jobs running on the same entry.

For now we are going to have lock for the score itself, which may cause the deadlocks in some scenarios, but as I said in the comment - I'm fine with it due to us having retry mechanism. 

![](https://media1.tenor.com/m/uRJWlUDvjyMAAAAC/lock-in-locked-in.gif)

This is not the best solution just to mention and deadlocks and be completely avoidable if we are going to more all data retrieval in the transaction scope, which what we basically do with refreshes. I'll consider this as another PR later, since I want to finish interface first. 

I'm also going to disable concurrency by default based on the mentioned deadlocks for the smoother experience. I would recommend to enable it if your server only needs it or you are fine with having deadlocks sometimes. Only way to have have concurrency enabled by default, is to complete the refactor as I mentioned above.